### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Next
 
+- **[Patch]** Update `main` in `package.json` to point to the correct file.
 - **[Internal]** Update dependencies. Drop dependency on `bluebird` in favor of
   native promises and `async`/`await`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Next
+
+- **[Internal]** Update dependencies. Drop dependency on `bluebird` in favor of
+  native promises and `async`/`await`.
+
 # 0.0.10
 
-Creation of `CHANGELOG.md`
+- **[Internal]** Create `CHANGELOG.md`

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "description": "Unofficial Skype API for Node.js via HTTP",
   "version": "0.0.10",
   "license": "MIT",
-  "main": "./dist/skype-http.js",
+  "main": "dist/lib-es2015/lib/skype-http.js",
+  "browser": "dist/lib-es5/lib/skype-http.js",
+  "types": "dist/lib-es2015/lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git://github.com/ocilo/skype-http.git"

--- a/package.json
+++ b/package.json
@@ -26,24 +26,28 @@
     "Skype-HTTP"
   ],
   "dependencies": {
+    "@types/lodash": "^4.14.64",
+    "@types/request": "0.0.43",
     "big-integer": "^1.5.6",
     "bluebird": "^3.3.5",
     "cheerio": "^0.19.0",
-    "incident": "^1.0.5",
     "js-sha256": "^0.3.0",
     "lodash": "^4.12.0",
     "request": "2.61",
     "tough-cookie": "^2.0.0"
   },
   "devDependencies": {
+    "@types/chai": "^3.5.2",
+    "@types/mocha": "^2.2.41",
+    "@types/node": "^7.0.18",
     "chai": "^3.5.0",
     "del": "^2.2.0",
-    "demurgos-web-build-tools": "0.13.0-beta.5",
+    "demurgos-web-build-tools": "^0.13.1",
     "fs-extra": "^0.30.0",
     "glob": "^7.0.3",
     "gulp": "github:gulpjs/gulp#4.0",
     "mocha": "^2.4.5",
     "pre-commit": "^1.2.2",
-    "typescript": "^2.1.4"
+    "typescript": "^2.3.2"
   }
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from "bluebird";
 import {EventEmitter} from "events";
 import acceptContactRequest from "./api/accept-contact-request";
 import declineContactRequest from "./api/decline-contact-request";
@@ -30,52 +29,54 @@ export class Api extends EventEmitter implements ApiEvents {
     this.messagesPoller.on("event-message", (ev: apiEvents.EventMessage) => this.handlePollingEvent(ev));
   }
 
-  acceptContactRequest(contactUsername: string): Bluebird<this> {
-    return acceptContactRequest(this.io, this.context, contactUsername).thenReturn(this);
+  async acceptContactRequest(contactUsername: string): Promise<this> {
+    await acceptContactRequest(this.io, this.context, contactUsername);
+    return this;
   }
 
-  declineContactRequest (contactUsername: string): Bluebird<this> {
-    return declineContactRequest(this.io, this.context, contactUsername).thenReturn(this);
+  async declineContactRequest (contactUsername: string): Promise<this> {
+    await declineContactRequest(this.io, this.context, contactUsername);
+    return this;
   }
 
-  getContact (contactId: string): Bluebird<Contact> {
+  getContact (contactId: string): Promise<Contact> {
     return getContact(this.io, this.context, contactId);
   }
 
-  getContacts (): Bluebird<Contact[]> {
+  getContacts (): Promise<Contact[]> {
     return getContacts(this.io, this.context);
   }
 
-  getConversation (conversationId: string): Bluebird<Conversation> {
+  getConversation (conversationId: string): Promise<Conversation> {
     return getConversation(this.io, this.context, conversationId);
   }
 
-  getConversations (): Bluebird<Conversation[]> {
+  getConversations (): Promise<Conversation[]> {
     return getConversations(this.io, this.context);
   }
 
-  sendMessage (message: api.NewMessage, conversationId: string): Bluebird<api.SendMessageResult> {
+  sendMessage (message: api.NewMessage, conversationId: string): Promise<api.SendMessageResult> {
     return sendMessage(this.io, this.context, message, conversationId);
   }
 
-  setStatus (status: api.Status): Bluebird<any> {
+  setStatus (status: api.Status): Promise<any> {
     return setStatus(this.io, this.context, status);
   }
 
   /**
    * Start polling and emitting events
    */
-  listen (): Bluebird<this> {
+  listen (): Promise<this> {
     this.messagesPoller.run();
-    return Bluebird.resolve(this);
+    return Promise.resolve(this);
   }
 
   /**
    * Stop polling and emitting events
    */
-  stopListening (): Bluebird<this> {
+  stopListening (): Promise<this> {
     this.messagesPoller.stop();
-    return Bluebird.resolve(this);
+    return Promise.resolve(this);
   }
 
   protected handlePollingEvent(ev: apiEvents.EventMessage): void {
@@ -85,7 +86,7 @@ export class Api extends EventEmitter implements ApiEvents {
       return;
     }
 
-    // Prevent echo
+    // Prevent infinite-loop (echo itself)
     if (ev.resource.from.username === this.context.username) {
       return;
     }

--- a/src/lib/api/accept-contact-request.ts
+++ b/src/lib/api/accept-contact-request.ts
@@ -1,28 +1,20 @@
-import * as Bluebird from "bluebird";
 import {Incident} from "incident";
 import * as apiUri from "../api-uri";
 import {Context} from "../interfaces/api/context";
 import * as io from "../interfaces/io";
 
-export function acceptContactRequest (io: io.HttpIo, apiContext: Context, contactUsername: string): Bluebird<any> {
-  return Bluebird
-    .try(() => {
-      const requestOptions: io.GetOptions = {
-        uri: apiUri.authRequestAccept(apiContext.username, contactUsername),
-        jar: apiContext.cookieJar,
-        headers: {
-          "X-Skypetoken": apiContext.skypeToken.value
-        }
-      };
-      return io.put(requestOptions);
-    })
-    .then((res: io.Response) => {
-      if (res.statusCode !== 201) {
-        return Bluebird.reject(new Incident("net", "Failed to accept contact"));
-      }
-      const body: any = JSON.parse(res.body);
-      return Bluebird.resolve(null);
-    });
+export async function acceptContactRequest(io: io.HttpIo, apiContext: Context, contactUsername: string): Promise<void> {
+  const requestOptions: io.GetOptions = {
+    uri: apiUri.authRequestAccept(apiContext.username, contactUsername),
+    jar: apiContext.cookieJar,
+    headers: {
+      "X-Skypetoken": apiContext.skypeToken.value
+    }
+  };
+  const res: io.Response = await io.put(requestOptions);
+  if (res.statusCode !== 201) {
+    return Promise.reject(new Incident("net", "Failed to accept contact"));
+  }
 }
 
 export default acceptContactRequest;

--- a/src/lib/api/decline-contact-request.ts
+++ b/src/lib/api/decline-contact-request.ts
@@ -1,28 +1,25 @@
-import * as Bluebird from "bluebird";
 import {Incident} from "incident";
 import * as apiUri from "../api-uri";
 import {Context} from "../interfaces/api/context";
 import * as io from "../interfaces/io";
 
-export function declineContactRequest (io: io.HttpIo, apiContext: Context, contactUsername: string): Bluebird<any> {
-  return Bluebird
-    .try(() => {
-      const requestOptions: io.GetOptions = {
-        uri: apiUri.authRequestDecline(apiContext.username, contactUsername),
-        jar: apiContext.cookieJar,
-        headers: {
-          "X-Skypetoken": apiContext.skypeToken.value
-        }
-      };
-      return io.put(requestOptions);
-    })
-    .then((res: io.Response) => {
-      if (res.statusCode !== 201) {
-        return Bluebird.reject(new Incident("net", "Failed to decline contact"));
-      }
-      const body: any = JSON.parse(res.body);
-      return Bluebird.resolve(null);
-    });
+export async function declineContactRequest(
+  io: io.HttpIo,
+  apiContext: Context,
+  contactUsername: string
+): Promise<void> {
+  const requestOptions: io.GetOptions = {
+    uri: apiUri.authRequestDecline(apiContext.username, contactUsername),
+    jar: apiContext.cookieJar,
+    headers: {
+      "X-Skypetoken": apiContext.skypeToken.value
+    }
+  };
+  const res: io.Response = await io.put(requestOptions);
+
+  if (res.statusCode !== 201) {
+    return Promise.reject(new Incident("net", "Failed to decline contact"));
+  }
 }
 
 export default declineContactRequest;

--- a/src/lib/api/get-contact.ts
+++ b/src/lib/api/get-contact.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from "bluebird";
 import {Incident} from "incident";
 import * as apiUri from "../api-uri";
 import {Contact} from "../interfaces/api/contact";
@@ -7,33 +6,29 @@ import * as io from "../interfaces/io";
 
 export const VIRTUAL_CONTACTS: Set<string> = new Set(["concierge", "echo123"]);
 
-export function getContact (io: io.HttpIo, apiContext: Context, contactId: string): Bluebird<Contact> {
-  return Bluebird
-    .try(() => {
-      if (VIRTUAL_CONTACTS.has(contactId)) {
-        // tslint:disable-next-line:max-line-length
-        throw new Error(`${JSON.stringify(contactId)} is not a real contact, you cannot get data for ${JSON.stringify(contactId)}`);
-      }
-      // concierge
-      console.log(`Getting contact: ${contactId}`);
-      const requestOptions: io.GetOptions = {
-        uri: apiUri.userProfile(contactId),
-        jar: apiContext.cookieJar,
-        headers: {
-          "X-Skypetoken": apiContext.skypeToken.value
-        }
-      };
-      return io.get(requestOptions);
-    })
-    .then((res: io.Response) => {
-      console.log(`Response for contact ${JSON.stringify(contactId)}:`);
-      console.log(res);
-      if (res.statusCode !== 200) {
-        return Bluebird.reject(new Incident("net", "Unable to fetch contact"));
-      }
-      const body: Contact = JSON.parse(res.body);
-      return body;
-    });
+export async function getContact(io: io.HttpIo, apiContext: Context, contactId: string): Promise<Contact> {
+  if (VIRTUAL_CONTACTS.has(contactId)) {
+    // tslint:disable-next-line:max-line-length
+    throw new Error(`${JSON.stringify(contactId)} is not a real contact, you cannot get data for ${JSON.stringify(contactId)}`);
+  }
+  // concierge
+  console.log(`Getting contact: ${contactId}`);
+  const requestOptions: io.GetOptions = {
+    uri: apiUri.userProfile(contactId),
+    jar: apiContext.cookieJar,
+    headers: {
+      "X-Skypetoken": apiContext.skypeToken.value
+    }
+  };
+  const res: io.Response = await io.get(requestOptions);
+
+  console.log(`Response for contact ${JSON.stringify(contactId)}:`);
+  console.log(res);
+  if (res.statusCode !== 200) {
+    return Promise.reject(new Incident("net", "Unable to fetch contact"));
+  }
+  const body: Contact = JSON.parse(res.body);
+  return body;
 }
 
 export default getContact;

--- a/src/lib/api/get-contacts.ts
+++ b/src/lib/api/get-contacts.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from "bluebird";
 import {Incident} from "incident";
 import * as _ from "lodash";
 import * as contactsUri from "../contacts-uri";
@@ -14,25 +13,21 @@ interface ContactsResponse {
   scope: "full" | string; // an enum ?
 }
 
-export function getContacts(io: io.HttpIo, apiContext: Context): Bluebird<Contact[]> {
-  return Bluebird
-    .try(() => {
-      const requestOptions: io.GetOptions = {
-        uri: contactsUri.contacts(apiContext.username),
-        jar: apiContext.cookieJar,
-        headers: {
-          "X-Skypetoken": apiContext.skypeToken.value
-        }
-      };
-      return io.get(requestOptions);
-    })
-    .then((res: io.Response) => {
-      if (res.statusCode !== 200) {
-        return Bluebird.reject(new Incident("net", "Unable to fetch contacts"));
-      }
-      const body: ContactsResponse = JSON.parse(res.body);
-      return _.map(body.contacts, formatContact);
-    });
+export async function getContacts(io: io.HttpIo, apiContext: Context): Promise<Contact[]> {
+  const requestOptions: io.GetOptions = {
+    uri: contactsUri.contacts(apiContext.username),
+    jar: apiContext.cookieJar,
+    headers: {
+      "X-Skypetoken": apiContext.skypeToken.value
+    }
+  };
+  const res: io.Response = await io.get(requestOptions);
+
+  if (res.statusCode !== 200) {
+    return Promise.reject(new Incident("net", "Unable to fetch contacts"));
+  }
+  const body: ContactsResponse = JSON.parse(res.body);
+  return _.map(body.contacts, formatContact);
 }
 
 export default getContacts;

--- a/src/lib/api/get-conversations.ts
+++ b/src/lib/api/get-conversations.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from "bluebird";
 import {Incident} from "incident";
 import * as _ from "lodash";
 import {Context} from "../interfaces/api/context";
@@ -24,32 +23,28 @@ interface GetConversationsQuery {
   targetType: string; // seen: Passport|Skype|Lync|Thread
 }
 
-export function getConversations (io: io.HttpIo, apiContext: Context): Bluebird<Conversation[]> {
-  return Bluebird
-    .try(() => {
-      const query: GetConversationsQuery = {
-        startTime: 0,
-        view: "msnp24Equivalent",
-        targetType: "Passport|Skype|Lync|Thread"
-      };
+export async function getConversations(io: io.HttpIo, apiContext: Context): Promise<Conversation[]> {
+  const query: GetConversationsQuery = {
+    startTime: 0,
+    view: "msnp24Equivalent",
+    targetType: "Passport|Skype|Lync|Thread"
+  };
 
-      const requestOptions: io.GetOptions = {
-        uri: messagesUri.conversations(apiContext.registrationToken.host, messagesUri.DEFAULT_USER),
-        jar: apiContext.cookieJar,
-        queryString: query,
-        headers: {
-          RegistrationToken: apiContext.registrationToken.raw
-        }
-      };
-      return io.get(requestOptions);
-    })
-    .then((res: io.Response) => {
-      if (res.statusCode !== 200) {
-        return Bluebird.reject(new Incident("net", "Unable to fetch conversations"));
-      }
-      const body: ConversationsBody = JSON.parse(res.body);
-      return _.map(body.conversations, formatConversation);
-    });
+  const requestOptions: io.GetOptions = {
+    uri: messagesUri.conversations(apiContext.registrationToken.host, messagesUri.DEFAULT_USER),
+    jar: apiContext.cookieJar,
+    queryString: query,
+    headers: {
+      RegistrationToken: apiContext.registrationToken.raw
+    }
+  };
+  const res: io.Response = await io.get(requestOptions);
+
+  if (res.statusCode !== 200) {
+    return Promise.reject(new Incident("net", "Unable to fetch conversations"));
+  }
+  const body: ConversationsBody = JSON.parse(res.body);
+  return _.map(body.conversations, formatConversation);
 }
 
 export default getConversations;

--- a/src/lib/api/send-message.ts
+++ b/src/lib/api/send-message.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from "bluebird";
 import {Incident} from "incident";
 import * as api from "../interfaces/api/api";
 import {Context} from "../interfaces/api/context";
@@ -17,38 +16,38 @@ interface SendMessageQuery {
   contenttype: string;
 }
 
-export function sendMessage(io: io.HttpIo, apiContext: Context, message: api.NewMessage,
-                            conversationId: string): Bluebird<api.SendMessageResult> {
-  return Bluebird
-    .try(() => {
-      const query: SendMessageQuery = {
-        clientmessageid: String(getCurrentTime() + Math.floor(10000 * Math.random())),
-        content: String(message.textContent),
-        messagetype: "RichText",
-        contenttype: "text"
-      };
-      const requestOptions: io.PostOptions = {
-        uri: messagesUri.messages(apiContext.registrationToken.host, messagesUri.DEFAULT_USER, conversationId),
-        jar: apiContext.cookieJar,
-        body: JSON.stringify(query),
-        headers: {
-          RegistrationToken: apiContext.registrationToken.raw
-        }
-      };
-      return io.post(requestOptions)
-        .then((res: io.Response) => {
-          console.log(JSON.stringify(res, null, 2));
-          if (res.statusCode !== 201) {
-            return Bluebird.reject(new Incident("send-message", "Received wrong return code"));
-          }
-          const body: SendMessageResponse = JSON.parse(res.body);
-          return {
-            clientMessageId: query.clientmessageid,
-            arrivalTime: body.OriginalArrivalTime,
-            textContent: query.content
-          };
-        });
-    });
+export async function sendMessage(
+  io: io.HttpIo, apiContext: Context,
+  message: api.NewMessage,
+  conversationId: string
+): Promise<api.SendMessageResult> {
+
+  const query: SendMessageQuery = {
+    clientmessageid: String(getCurrentTime() + Math.floor(10000 * Math.random())),
+    content: String(message.textContent),
+    messagetype: "RichText",
+    contenttype: "text"
+  };
+  const requestOptions: io.PostOptions = {
+    uri: messagesUri.messages(apiContext.registrationToken.host, messagesUri.DEFAULT_USER, conversationId),
+    jar: apiContext.cookieJar,
+    body: JSON.stringify(query),
+    headers: {
+      RegistrationToken: apiContext.registrationToken.raw
+    }
+  };
+  const res: io.Response = await io.post(requestOptions);
+
+  console.log(JSON.stringify(res, null, 2));
+  if (res.statusCode !== 201) {
+    return Promise.reject(new Incident("send-message", "Received wrong return code"));
+  }
+  const body: SendMessageResponse = JSON.parse(res.body);
+  return {
+    clientMessageId: query.clientmessageid,
+    arrivalTime: body.OriginalArrivalTime,
+    textContent: query.content
+  };
 }
 
 export default sendMessage;

--- a/src/lib/api/set-status.ts
+++ b/src/lib/api/set-status.ts
@@ -1,6 +1,4 @@
-import * as Bluebird from "bluebird";
 import {Incident} from "incident";
-
 import * as api from "../interfaces/api/api";
 import {Context} from "../interfaces/api/context";
 import * as io from "../interfaces/io";
@@ -10,28 +8,23 @@ interface RequestBody {
   status: string;
 }
 
-export function setStatus (io: io.HttpIo, apiContext: Context, status: api.Status): Bluebird<any> {
-  return Bluebird
-    .try(() => {
-      const requestBody: RequestBody = {
-        status: status
-      };
-      const requestOptions: io.PostOptions = {
-        uri: messagesUri.userMessagingService(apiContext.registrationToken.host),
-        jar: apiContext.cookieJar,
-        body: JSON.stringify(requestBody),
-        headers: {
-          RegistrationToken: apiContext.registrationToken.raw
-        }
-      };
-      return io.put(requestOptions);
-    })
-    .then((res: io.Response) => {
-      if (res.statusCode !== 200) {
-        return Bluebird.reject(new Incident("send-message", "Received wrong return code"));
-      }
-      return;
-    });
+export async function setStatus(io: io.HttpIo, apiContext: Context, status: api.Status): Promise<void> {
+  const requestBody: RequestBody = {
+    status: status
+  };
+  const requestOptions: io.PostOptions = {
+    uri: messagesUri.userMessagingService(apiContext.registrationToken.host),
+    jar: apiContext.cookieJar,
+    body: JSON.stringify(requestBody),
+    headers: {
+      RegistrationToken: apiContext.registrationToken.raw
+    }
+  };
+  const res: io.Response = await io.put(requestOptions);
+
+  if (res.statusCode !== 200) {
+    return Promise.reject(new Incident("send-message", "Received wrong return code"));
+  }
 }
 
 export default setStatus;

--- a/src/lib/connect.ts
+++ b/src/lib/connect.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from "bluebird";
 import {Incident} from "incident";
 import * as api from "./api";
 import {Credentials} from "./interfaces/api/api";
@@ -16,28 +15,24 @@ export interface ConnectOptions {
   verbose?: boolean;
 }
 
-export function connect(options: ConnectOptions): Bluebird<api.Api> {
+export async function connect(options: ConnectOptions): Promise<api.Api> {
   if (options.state !== undefined) {
-    return Bluebird.reject(new Incident("todo", "Connection from previous state is not yet supported."));
+    return Promise.reject(new Incident("todo", "Connection from previous state is not yet supported."));
   } else if (options.credentials === undefined) {
-    return Bluebird.reject(new Incident("todo", "Connect must define `credentials`"));
-  } else {
-    const apiPromise: Promise<Context> = login({
-      io: requestIO,
-      credentials: options.credentials,
-      verbose: options.verbose
-    });
-    return Bluebird.resolve(apiPromise)
-      .then((apiContext: Context) => {
-        if (options.verbose) {
-          console.log("Obtained context trough authentication:");
-          console.log({
-            username: apiContext.username,
-            skypeToken: apiContext.skypeToken,
-            registrationToken: apiContext.registrationToken
-          });
-        }
-        return new api.Api(apiContext, requestIO);
-      });
+    return Promise.reject(new Incident("todo", "Connect must define `credentials`"));
   }
+  const apiContext: Context = await login({
+    io: requestIO,
+    credentials: options.credentials,
+    verbose: options.verbose
+  });
+  if (options.verbose) {
+    console.log("Obtained context trough authentication:");
+    console.log({
+      username: apiContext.username,
+      skypeToken: apiContext.skypeToken,
+      registrationToken: apiContext.registrationToken
+    });
+  }
+  return new api.Api(apiContext, requestIO);
 }

--- a/src/lib/login.spec.ts
+++ b/src/lib/login.spec.ts
@@ -4,7 +4,7 @@ import {login, LoginOptions} from "./login";
 import {requestIo} from "./request-io";
 
 describe.skip("login", function() {
-  describe("login", async function(this: Mocha.IContextDefinition) {
+  describe("login", async function(this: Mocha.ISuiteCallbackContext) {
     this.timeout(10 * 60 * 1000); // 10 minutes
 
     it("Should log into the main test account", async function() {

--- a/src/lib/providers/microsoft-account.spec.ts
+++ b/src/lib/providers/microsoft-account.spec.ts
@@ -13,8 +13,8 @@ import {
   SkypeTokenResponse
 } from "./microsoft-account";
 
-describe("Microsoft Account provider", function (this: Mocha.IContextDefinition) {
-  describe.skip("getSkypeToken", async function (this: Mocha.IContextDefinition) {
+describe("Microsoft Account provider", function (this: Mocha.ISuiteCallbackContext) {
+  describe.skip("getSkypeToken", async function (this: Mocha.ISuiteCallbackContext) {
     this.timeout(10 * 60 * 1000); // 10 minutes
 
     it("Should get a skype token for the main test account", async function () {

--- a/src/lib/providers/microsoft-account.ts
+++ b/src/lib/providers/microsoft-account.ts
@@ -117,7 +117,8 @@ export async function getLiveKeys(options: LoadLiveKeysOptions): Promise<LiveKey
   let mspOk: string | undefined;
 
   // Retrieve values for the cookies "MSPRequ" and "MSPOK"
-  const cookies: Cookie[] = options.cookieJar.getCookies("https://login.live.com/");
+  // TODO(demurgos): Remove this <any>
+  const cookies: Cookie[] = <any> options.cookieJar.getCookies("https://login.live.com/");
   for (const cookie of cookies) {
     switch (cookie.key) {
       case "MSPRequ":
@@ -201,7 +202,8 @@ export async function requestLiveToken (options: SendCredentialsOptions): Promis
     key: "CkTst",
     value: millisecondsSinceEpoch.toString(10)
   });
-  jar.setCookie(ckTstCookie, "https://login.live.com/");
+  // TODO(demurgos): Remove this <any>
+  jar.setCookie(<any> ckTstCookie, "https://login.live.com/");
 
   const formData: Dictionary<string> = {
     login: options.username,

--- a/src/lib/request-io.ts
+++ b/src/lib/request-io.ts
@@ -1,4 +1,3 @@
-import Bluebird = require("bluebird");
 import request = require("request");
 import * as io from "./interfaces/io";
 
@@ -23,14 +22,14 @@ function asRequestOptions (ioOptions: io.GetOptions | io.PostOptions | io.PutOpt
  * @param options
  * @returns {Bluebird<any>}
  */
-export function get (options: io.GetOptions): Bluebird<io.Response> {
-  return Bluebird.fromCallback((cb) => {
+export function get (options: io.GetOptions): Promise<io.Response> {
+  return new Promise((resolve, reject) => {
     request.get(asRequestOptions(options), (error, response, body) => {
       if (error) {
-        return cb(error);
+        return reject(error);
       }
       if (response.statusCode === undefined) {
-        return cb(new Error("Missing status code"));
+        return reject(new Error("Missing status code"));
       }
 
       const ioResponse: io.Response = {
@@ -39,7 +38,7 @@ export function get (options: io.GetOptions): Bluebird<io.Response> {
         headers: response.headers
       };
 
-      cb(null, ioResponse);
+      resolve(ioResponse);
     });
   });
 }
@@ -50,14 +49,14 @@ export function get (options: io.GetOptions): Bluebird<io.Response> {
  * @param options
  * @returns {Bluebird<any>}
  */
-export function post (options: io.PostOptions): Bluebird<io.Response> {
-  return Bluebird.fromCallback((cb) => {
+export function post (options: io.PostOptions): Promise<io.Response> {
+  return new Promise((resolve, reject) => {
     request.post(asRequestOptions(options), (error, response, body) => {
       if (error) {
-        return cb(error);
+        return reject(error);
       }
       if (response.statusCode === undefined) {
-        return cb(new Error("Missing status code"));
+        return reject(new Error("Missing status code"));
       }
 
       const ioResponse: io.Response = {
@@ -66,7 +65,7 @@ export function post (options: io.PostOptions): Bluebird<io.Response> {
         headers: response.headers
       };
 
-      cb(null, ioResponse);
+      resolve(ioResponse);
     });
   });
 }
@@ -77,14 +76,14 @@ export function post (options: io.PostOptions): Bluebird<io.Response> {
  * @param options
  * @returns {Bluebird<any>}
  */
-export function put (options: io.PutOptions): Bluebird<io.Response> {
-  return Bluebird.fromCallback((cb) => {
+export function put (options: io.PutOptions): Promise<io.Response> {
+  return new Promise((resolve, reject) => {
     request.put(asRequestOptions(options), (error, response, body) => {
       if (error) {
-        return cb(error);
+        return reject(error);
       }
       if (response.statusCode === undefined) {
-        return cb(new Error("Missing status code"));
+        return reject(new Error("Missing status code"));
       }
 
       const ioResponse: io.Response = {
@@ -93,7 +92,7 @@ export function put (options: io.PutOptions): Bluebird<io.Response> {
         headers: response.headers
       };
 
-      cb(null, ioResponse);
+      resolve(ioResponse);
     });
   });
 }

--- a/src/test/end-to-end/skype-http.spec.ts
+++ b/src/test/end-to-end/skype-http.spec.ts
@@ -1,5 +1,5 @@
 import {assert} from "chai";
-import {IContextDefinition} from "mocha";
+import {ISuiteCallbackContext} from "mocha";
 import {Api} from "../../lib/api";
 import * as SkypeHttp from "../../lib/connect";
 import {Credentials} from "../../lib/interfaces/api/api";
@@ -7,7 +7,7 @@ import testConfig from "../test-config";
 
 const mainAccount: Credentials = testConfig.credentials;
 
-describe.skip("SkypeHttp", function(this: IContextDefinition) {
+describe.skip("SkypeHttp", function(this: ISuiteCallbackContext) {
   this.timeout(20000); // 20 seconds
 
   it("should connect to the main account trough authentication", function() {

--- a/tslint.json
+++ b/tslint.json
@@ -80,7 +80,7 @@
     "no-invalid-this": false,
     "no-magic-numbers": false,
     "no-mergeable-namespace": true,
-    "no-namespace": true,
+    "no-namespace": false,
     "no-null-keyword": false,
     "no-parameter-properties": true,
     "no-reference": true,

--- a/typings.json
+++ b/typings.json
@@ -1,23 +1,12 @@
 {
-  "name": "hammerfest-api",
   "dependencies": {
     "big-integer": "registry:npm/big-integer#1.6.15+20160501004755",
-    "bluebird": "registry:npm/bluebird#3.4.1+20160909132857",
     "cheerio": "registry:npm/cheerio#0.20.0+20160422172414",
     "form-data": "registry:npm/form-data#1.0.0+20160211003958",
-    "incident": "npm:incident",
     "js-sha256": "registry:npm/js-sha256#0.3.0+20160427051917",
-    "lodash": "registry:npm/lodash#4.0.0+20161015015725",
-    "request": "registry:npm/request#2.69.0+20160428223725",
     "tough-cookie": "registry:npm/tough-cookie#2.2.0+20160723033700"
   },
-  "devDependencies": {
-    "chai": "registry:npm/chai#3.5.0+20160723033700"
-  },
-  "globalDependencies": {
-    "node": "registry:env/node#6.0.0+20170102175725"
-  },
-  "globalDevDependencies": {
-    "mocha": "registry:env/mocha#2.2.5+20160926180742"
-  }
+  "devDependencies": {},
+  "globalDependencies": {},
+  "globalDevDependencies": {}
 }


### PR DESCRIPTION
- Drop Bluebird
- Incident 2
- Typescript 2.3
- Build-tools 0.13.1
- Use `@types` instead of `typings` for mocha, node, chai,  lodash and request

This MR also patches the entry point of the package.