### PR TITLE
save/load state support (somewhat hacky)

### DIFF
--- a/src/custom-typings/tough-cookie/index.d.ts
+++ b/src/custom-typings/tough-cookie/index.d.ts
@@ -110,10 +110,83 @@ export function permutePath (path: string): string[];
 
 /**
  * Base class for CookieJar stores. Available as tough.Store.
+ *
+ * @see https://github.com/SalesforceEng/tough-cookie#store
  */
 export class Store {
-  // TODO(blakeembrey): Finish this.
-  // https://github.com/SalesforceEng/tough-cookie#store
+  get synchronous(): this is StoreSync;
+
+  /**
+   * Retrieve a cookie with the given domain, path and key (a.k.a. name).
+   */
+  findCookie(domain: string, path: string, key: string, cb: (err: Error | null, cookie: Cookie) => void);
+
+  /**
+   * Locates cookies matching the given domain and path.
+   */
+  findCookies(domain: string, path: string, key: string, cb: (err: Error | null, cookies: Cookie[]) => void);
+
+  /**
+   * Adds a new cookie to the store.
+   */
+  putCookie(cookie: Cookie, cb: (err: Error | null) => void);
+
+  /**
+   * Update an existing cookie.
+   */
+  updateCookie(oldCookie: Cookie, newCookie: Cookie, cb: (err: Error | null) => void);
+
+  /**
+   * Remove a cookie from the store.
+   */
+  removeCookie(domain: string, path: string, key: string, cb: (err: Error | null) => void);
+
+  /**
+   * Removes matching cookies from the store.
+   */
+  removeCookies(domain: string, path: string, cb: (err: Error | null) => void);
+
+  /**
+   * Produces an `Array` of all cookies during `jar.serialize()`.
+   */
+  getAllCookies(cb: (err: Error | null, cookies: Cookie[]) => void);
+}
+
+export interface StoreSync extends Store {
+  /**
+   * Retrieve a cookie with the given domain, path and key (a.k.a. name).
+   */
+  findCookieSync(domain: string, path: string, key: string): Cookie;
+
+  /**
+   * Locates cookies matching the given domain and path.
+   */
+  findCookiesSync(domain: string, path: string, key: string): Cookie[];
+
+  /**
+   * Adds a new cookie to the store.
+   */
+  putCookieSync(cookie: Cookie): void;
+
+  /**
+   * Update an existing cookie.
+   */
+  updateCookieSync(oldCookie: Cookie, newCookie: Cookie): void;
+
+  /**
+   * Remove a cookie from the store.
+   */
+  removeCookieSync(domain: string, path: string, key: string): void;
+
+  /**
+   * Removes matching cookies from the store.
+   */
+  removeCookiesSync(domain: string, path: string): void;
+
+  /**
+   * Produces an `Array` of all cookies during `jar.serialize()`.
+   */
+  getAllCookiesSync(): Cookie[];
 }
 
 /**
@@ -475,7 +548,7 @@ export class CookieJar {
    * Sync version of .deserialize. Note that the store must be synchronous
    * for this to work.
    */
-  static deserializeSync (serialized: string | Object, store: Store): Object;
+  static deserializeSync (serialized: string | Object, store: Store): CookieJar;
 
   /**
    * Alias of .deserializeSync to provide consistency with Cookie.fromJSON().

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,5 @@
-import {EventEmitter} from "events";
+﻿ import {EventEmitter} from "events";
+import { CookieJar as CookieJar2 } from "tough-cookie";
 import acceptContactRequest from "./api/accept-contact-request";
 import declineContactRequest from "./api/decline-contact-request";
 import getContact from "./api/get-contact";
@@ -7,9 +8,10 @@ import getConversation from "./api/get-conversation";
 import getConversations from "./api/get-conversations";
 import sendMessage from "./api/send-message";
 import setStatus from "./api/set-status";
+import { StateObj } from "./connect";
 import * as api from "./interfaces/api/api";
 import {Contact} from "./interfaces/api/contact";
-import {Context as ApiContext} from "./interfaces/api/context";
+import { Context as ApiContext } from "./interfaces/api/context";
 import {Conversation} from "./interfaces/api/conversation";
 import * as apiEvents from "./interfaces/api/events";
 import {HttpIo} from "./interfaces/http-io";
@@ -59,6 +61,15 @@ export class Api extends EventEmitter implements ApiEvents {
     return sendMessage(this.io, this.context, message, conversationId);
   }
 
+  getState(): Promise<StateObj> {
+    const jar: CookieJar2 = new CookieJar2(this.context.cookieStore);
+    const obj: StateObj = {
+        cookieJar: JSON.stringify(jar.toJSON()), username: this.context.username,
+        registrationToken: JSON.stringify(this.context.registrationToken),
+        skypeToken: JSON.stringify(this.context.skypeToken),
+    };
+    return Promise.resolve(obj);
+  }
   setStatus (status: api.Status): Promise<any> {
     return setStatus(this.io, this.context, status);
   }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,4 @@
-﻿ import {EventEmitter} from "events";
-import { CookieJar as CookieJar2 } from "tough-cookie";
+﻿import {EventEmitter} from "events";
 import acceptContactRequest from "./api/accept-contact-request";
 import declineContactRequest from "./api/decline-contact-request";
 import getContact from "./api/get-contact";
@@ -8,10 +7,9 @@ import getConversation from "./api/get-conversation";
 import getConversations from "./api/get-conversations";
 import sendMessage from "./api/send-message";
 import setStatus from "./api/set-status";
-import { StateObj } from "./connect";
 import * as api from "./interfaces/api/api";
 import {Contact} from "./interfaces/api/contact";
-import { Context as ApiContext } from "./interfaces/api/context";
+import {Context as ApiContext} from "./interfaces/api/context";
 import {Conversation} from "./interfaces/api/conversation";
 import * as apiEvents from "./interfaces/api/events";
 import {HttpIo} from "./interfaces/http-io";
@@ -22,7 +20,7 @@ export class Api extends EventEmitter implements ApiEvents {
   context: ApiContext;
   messagesPoller: MessagesPoller;
 
-  constructor (context: ApiContext, io: HttpIo) {
+  constructor(context: ApiContext, io: HttpIo) {
     super();
     this.context = context;
     this.io = io;
@@ -36,48 +34,43 @@ export class Api extends EventEmitter implements ApiEvents {
     return this;
   }
 
-  async declineContactRequest (contactUsername: string): Promise<this> {
+  async declineContactRequest(contactUsername: string): Promise<this> {
     await declineContactRequest(this.io, this.context, contactUsername);
     return this;
   }
 
-  getContact (contactId: string): Promise<Contact> {
+  getContact(contactId: string): Promise<Contact> {
     return getContact(this.io, this.context, contactId);
   }
 
-  getContacts (): Promise<Contact[]> {
+  getContacts(): Promise<Contact[]> {
     return getContacts(this.io, this.context);
   }
 
-  getConversation (conversationId: string): Promise<Conversation> {
+  getConversation(conversationId: string): Promise<Conversation> {
     return getConversation(this.io, this.context, conversationId);
   }
 
-  getConversations (): Promise<Conversation[]> {
+  getConversations(): Promise<Conversation[]> {
     return getConversations(this.io, this.context);
   }
 
-  sendMessage (message: api.NewMessage, conversationId: string): Promise<api.SendMessageResult> {
+  sendMessage(message: api.NewMessage, conversationId: string): Promise<api.SendMessageResult> {
     return sendMessage(this.io, this.context, message, conversationId);
   }
 
-  getState(): Promise<StateObj> {
-    const jar: CookieJar2 = new CookieJar2(this.context.cookieStore);
-    const obj: StateObj = {
-        cookieJar: JSON.stringify(jar.toJSON()), username: this.context.username,
-        registrationToken: JSON.stringify(this.context.registrationToken),
-        skypeToken: JSON.stringify(this.context.skypeToken),
-    };
-    return Promise.resolve(obj);
+  getState(): ApiContext.Json {
+    return ApiContext.toJson(this.context);
   }
-  setStatus (status: api.Status): Promise<any> {
+
+  setStatus(status: api.Status): Promise<any> {
     return setStatus(this.io, this.context, status);
   }
 
   /**
    * Start polling and emitting events
    */
-  listen (): Promise<this> {
+  listen(): Promise<this> {
     this.messagesPoller.run();
     return Promise.resolve(this);
   }
@@ -85,7 +78,7 @@ export class Api extends EventEmitter implements ApiEvents {
   /**
    * Stop polling and emitting events
    */
-  stopListening (): Promise<this> {
+  stopListening(): Promise<this> {
     this.messagesPoller.stop();
     return Promise.resolve(this);
   }

--- a/src/lib/api/accept-contact-request.ts
+++ b/src/lib/api/accept-contact-request.ts
@@ -6,7 +6,7 @@ import * as io from "../interfaces/http-io";
 export async function acceptContactRequest(io: io.HttpIo, apiContext: Context, contactUsername: string): Promise<void> {
   const requestOptions: io.GetOptions = {
     uri: apiUri.authRequestAccept(apiContext.username, contactUsername),
-    jar: apiContext.cookieJar,
+    cookies: apiContext.cookies,
     headers: {
       "X-Skypetoken": apiContext.skypeToken.value,
     },

--- a/src/lib/api/decline-contact-request.ts
+++ b/src/lib/api/decline-contact-request.ts
@@ -10,7 +10,7 @@ export async function declineContactRequest(
 ): Promise<void> {
   const requestOptions: io.GetOptions = {
     uri: apiUri.authRequestDecline(apiContext.username, contactUsername),
-    jar: apiContext.cookieJar,
+    cookies: apiContext.cookies,
     headers: {
       "X-Skypetoken": apiContext.skypeToken.value,
     },

--- a/src/lib/api/get-contact.ts
+++ b/src/lib/api/get-contact.ts
@@ -14,7 +14,7 @@ export async function getContact(io: io.HttpIo, apiContext: Context, contactId: 
   }
   const requestOptions: io.PostOptions = {
     uri: apiUri.userProfiles(),
-    jar: apiContext.cookieJar,
+    cookies: apiContext.cookies,
     form: { usernames: [contactId] },
     headers: {
       "X-Skypetoken": apiContext.skypeToken.value,

--- a/src/lib/api/get-contacts.ts
+++ b/src/lib/api/get-contacts.ts
@@ -15,7 +15,7 @@ interface ContactsResponse {
 export async function getContacts(io: io.HttpIo, apiContext: Context): Promise<Contact[]> {
   const requestOptions: io.GetOptions = {
     uri: contactsUri.contacts(apiContext.username),
-    jar: apiContext.cookieJar,
+    cookies: apiContext.cookies,
     headers: {
       "X-Skypetoken": apiContext.skypeToken.value,
     },

--- a/src/lib/api/get-conversation.ts
+++ b/src/lib/api/get-conversation.ts
@@ -45,7 +45,7 @@ export async function getConversation(
 
   const requestOptions: io.GetOptions = {
     uri: uri,
-    jar: apiContext.cookieJar,
+    cookies: apiContext.cookies,
     queryString: query,
     headers: {
       RegistrationToken: apiContext.registrationToken.raw,

--- a/src/lib/api/get-conversations.ts
+++ b/src/lib/api/get-conversations.ts
@@ -32,7 +32,7 @@ export async function getConversations(io: io.HttpIo, apiContext: Context): Prom
 
   const requestOptions: io.GetOptions = {
     uri: messagesUri.conversations(apiContext.registrationToken.host, messagesUri.DEFAULT_USER),
-    jar: apiContext.cookieJar,
+    cookies: apiContext.cookies,
     queryString: query,
     headers: {
       RegistrationToken: apiContext.registrationToken.raw,

--- a/src/lib/api/send-message.ts
+++ b/src/lib/api/send-message.ts
@@ -30,7 +30,7 @@ export async function sendMessage(
   };
   const requestOptions: io.PostOptions = {
     uri: messagesUri.messages(apiContext.registrationToken.host, messagesUri.DEFAULT_USER, conversationId),
-    jar: apiContext.cookieJar,
+    cookies: apiContext.cookies,
     body: JSON.stringify(query),
     headers: {
       RegistrationToken: apiContext.registrationToken.raw,

--- a/src/lib/api/set-status.ts
+++ b/src/lib/api/set-status.ts
@@ -14,7 +14,7 @@ export async function setStatus(io: io.HttpIo, apiContext: Context, status: api.
   };
   const requestOptions: io.PostOptions = {
     uri: messagesUri.userMessagingService(apiContext.registrationToken.host),
-    jar: apiContext.cookieJar,
+    cookies: apiContext.cookies,
     body: JSON.stringify(requestBody),
     headers: {
       RegistrationToken: apiContext.registrationToken.raw,

--- a/src/lib/connect.ts
+++ b/src/lib/connect.ts
@@ -1,8 +1,11 @@
-import {Incident} from "incident";
+﻿ import {Incident} from "incident";
+import { CookieJar } from "request";
+import * as request from "request";
+import { CookieJar as CookieJar2, MemoryCookieStore } from "tough-cookie";
 import * as api from "./api";
 import {Credentials} from "./interfaces/api/api";
 import {Context} from "./interfaces/api/context";
-import {login} from "./login";
+import {login, loginResume} from "./login";
 import requestIO from "./request-io";
 
 export interface StateContainer {
@@ -11,10 +14,16 @@ export interface StateContainer {
 
 export interface ConnectOptions {
   credentials?: Credentials;
-  state?: any;
+  state?: StateObj;
   verbose?: boolean;
 }
 
+export interface StateObj {
+  skypeToken: string;
+  registrationToken: string;
+  username: string;
+  cookieJar: string;
+}
 /**
  * Authenticate the user and create a new API.
  *
@@ -23,23 +32,37 @@ export interface ConnectOptions {
  * @throws [[LoginError]]
  */
 export async function connect(options: ConnectOptions): Promise<api.Api> {
+  let apiContext: Context;
   if (options.state !== undefined) {
-    return Promise.reject(new Incident("todo", "Connection from previous state is not yet supported."));
-  } else if (options.credentials === undefined) {
-    return Promise.reject(new Incident("todo", "Connect must define `credentials`"));
-  }
-  const apiContext: Context = await login({
-    io: requestIO,
-    credentials: options.credentials,
-    verbose: options.verbose,
-  });
-  if (options.verbose) {
-    console.log("Obtained context trough authentication:");
+    const store: MemoryCookieStore = new MemoryCookieStore();
+    CookieJar2.deserializeSync(options.state.cookieJar, store);
+    request.defaults({ jar: request.jar(store) });
+    apiContext = await loginResume({  //  registrationToken: JSON.parse(options.state.registrationToken)
+      io: requestIO, cookieStore: store, cookieJar: request.jar(store),
+      skypeToken: JSON.parse(options.state.skypeToken),
+      registrationToken: null, verbose: options.verbose, username: options.state.username});
     console.log({
       username: apiContext.username,
       skypeToken: apiContext.skypeToken,
       registrationToken: apiContext.registrationToken,
     });
+  } else if (options.credentials) {
+    apiContext = await login({
+      io: requestIO,
+      credentials: options.credentials,
+      verbose: options.verbose,
+    });
+    if (options.verbose) {
+      console.log("Obtained context trough authentication:");
+      console.log({
+        username: apiContext.username,
+        skypeToken: apiContext.skypeToken,
+        registrationToken: apiContext.registrationToken,
+      });
+    }
+
+  } else {
+    return Promise.reject(new Incident("todo", "Connect must define `credentials`"));
   }
   return new api.Api(apiContext, requestIO);
 }

--- a/src/lib/interfaces/api/context.ts
+++ b/src/lib/interfaces/api/context.ts
@@ -1,8 +1,9 @@
-import {CookieJar} from "request";
+﻿import { CookieJar } from "request";
 
 export interface Context {
   username: string;
   cookieJar: CookieJar;
+  cookieStore: any;
   skypeToken: SkypeToken;
   registrationToken: RegistrationToken;
 }

--- a/src/lib/interfaces/api/context.ts
+++ b/src/lib/interfaces/api/context.ts
@@ -1,22 +1,133 @@
-﻿import { CookieJar } from "request";
+﻿import {CookieJar, MemoryCookieStore, Store as CookieStore} from "tough-cookie";
 
-export interface Context {
-  username: string;
-  cookieJar: CookieJar;
-  cookieStore: any;
-  skypeToken: SkypeToken;
-  registrationToken: RegistrationToken;
-}
-
+/**
+ * Represents the OAuth token used for most calls to the Skype API.
+ */
 export interface SkypeToken {
   value: string;
   expirationDate: Date;
 }
 
+export namespace SkypeToken {
+  /**
+   * JSON-safe representation of `SkypeToken`, used for serialization.
+   */
+  export interface Json {
+    value: string;
+    expirationDate: string;
+  }
+
+  /**
+   * Export a SkypeToken to a JSON-safe object.
+   */
+  export function toJson(token: SkypeToken): SkypeToken.Json {
+    return {
+      value: token.value,
+      expirationDate: token.expirationDate.toISOString(),
+    };
+  }
+
+  /**
+   * Import a SkypeToken from a JSON-safe object.
+   */
+  export function fromJson(token: SkypeToken.Json): SkypeToken {
+    return {
+      value: token.value,
+      expirationDate: new Date(token.expirationDate),
+    };
+  }
+}
+
+/**
+ * Represents the OAuth registration token. This token allows to subscribe to resources (receive messages).
+ */
 export interface RegistrationToken {
   value: string;
   expirationDate: Date;
   endpointId: string;
   host: string;
-  raw?: string;
+  raw: string;
+}
+
+export namespace RegistrationToken {
+  /**
+   * JSON-safe representation of `RegistrationToken`, used for serialization.
+   */
+  export interface Json {
+    value: string;
+    expirationDate: string;
+    endpointId: string;
+    host: string;
+    raw: string;
+  }
+
+  /**
+   * Export a RegistrationToken to a JSON-safe object.
+   */
+  export function toJson(token: RegistrationToken): RegistrationToken.Json {
+    return {
+      value: token.value,
+      expirationDate: token.expirationDate.toISOString(),
+      endpointId: token.endpointId,
+      host: token.host,
+      raw: token.raw,
+    };
+  }
+
+  /**
+   * Import a RegistrationToken from a JSON-safe object.
+   */
+  export function fromJson(token: RegistrationToken.Json): RegistrationToken {
+    return {
+      value: token.value,
+      expirationDate: new Date(token.expirationDate),
+      endpointId: token.endpointId,
+      host: token.host,
+      raw: token.raw,
+    };
+  }
+}
+
+/**
+ * API context (state).
+ */
+// TODO(demurgos): Rename to `State` or even `ApiState` so it's easier to understand the purpose of this interface.
+export interface Context {
+  username: string;
+  cookies: CookieStore;
+  skypeToken: SkypeToken;
+  registrationToken: RegistrationToken;
+}
+
+export namespace Context {
+  /**
+   * JSON-safe representation of `Context`.
+   */
+  export interface Json {
+    username: string;
+    cookies: Object;
+    skypeToken: SkypeToken.Json;
+    registrationToken: RegistrationToken.Json;
+  }
+
+  export function toJson(context: Context): Context.Json {
+    return {
+      username: context.username,
+      cookies: new CookieJar(context.cookies).serializeSync(),
+      skypeToken: SkypeToken.toJson(context.skypeToken),
+      registrationToken: RegistrationToken.toJson(context.registrationToken),
+    };
+  }
+
+  export function fromJson(context: Context.Json): Context {
+    const cookies: MemoryCookieStore = new MemoryCookieStore();
+    CookieJar.deserializeSync(context.cookies, cookies);
+
+    return {
+      username: context.username,
+      cookies,
+      skypeToken: SkypeToken.fromJson(context.skypeToken),
+      registrationToken: RegistrationToken.fromJson(context.registrationToken),
+    };
+  }
 }

--- a/src/lib/interfaces/http-io.ts
+++ b/src/lib/interfaces/http-io.ts
@@ -1,9 +1,9 @@
-import {CookieJar} from "request";
+import {Store as CookieStore} from "tough-cookie";
 import {Dictionary} from "./utils";
 
 export interface BaseOptions {
   uri: string;
-  jar?: CookieJar;
+  cookies?: CookieStore;
   headers?: Dictionary<any>;
   queryString?: Dictionary<any>;
 }

--- a/src/lib/polling/messages-poller.ts
+++ b/src/lib/polling/messages-poller.ts
@@ -180,7 +180,7 @@ export class MessagesPoller extends EventEmitter {
       const requestOptions: httpIo.PostOptions = {
         // TODO: explicitly define user, endpoint and subscription
         uri: messagesUri.poll(this.apiContext.registrationToken.host),
-        jar: this.apiContext.cookieJar,
+        cookies: this.apiContext.cookies,
         headers: {
           RegistrationToken: this.apiContext.registrationToken.raw,
         },

--- a/src/lib/request-io.ts
+++ b/src/lib/request-io.ts
@@ -9,9 +9,12 @@ import * as io from "./interfaces/http-io";
  * @returns {request.Options} Corresponding `request` options
  */
 function asRequestOptions (ioOptions: io.GetOptions | io.PostOptions | io.PutOptions): request.Options {
-  const result: request.Options = Object.assign({}, ioOptions);
-  if (ioOptions.queryString) {
+  const result: request.Options = {...ioOptions};
+  if (ioOptions.queryString !== undefined) {
     result.qs = ioOptions.queryString;
+  }
+  if (ioOptions.cookies !== undefined) {
+    result.jar = request.jar(ioOptions.cookies);
   }
   return result;
 }

--- a/src/test/providers/microsoft-account.spec.ts
+++ b/src/test/providers/microsoft-account.spec.ts
@@ -1,5 +1,5 @@
 import {assert} from "chai";
-import * as request from "request";
+import {MemoryCookieStore} from "tough-cookie";
 import {SkypeToken} from "../../lib/interfaces/api/context";
 import {
   login,
@@ -24,7 +24,7 @@ describe("Microsoft Account provider", function (this: Mocha.ISuiteCallbackConte
           password: testConfig.credentials.password,
         },
         httpIo: requestIo,
-        cookieJar: request.jar(),
+        cookies: new MemoryCookieStore(),
       };
       const skypeToken: SkypeToken = await login(options);
       assert.property(skypeToken, "value");


### PR DESCRIPTION
I figured before working on other things reduce the number of times logging into the skype account and get serialization working.

Sample use case:
```
if (fs.existsSync("state.json")) {
		let state = fs.readFileSync("state.json", 'utf8');
		api = await skypeHttp.connect({ verbose: true, state: JSON.parse(state) });
	} else {
		api = await skypeHttp.connect({ verbose: true, credentials: { username: "<user>", password: "<pass>" } });
		fs.writeFileSync("state.json", JSON.stringify(await api.getState()));
	}
```
So it works but all I am really able to save out is the skype token.  Even serializing everything else I could see making the "state" I need to re-run the registration token to generate the endpoint.   If all we want to serialize is the skype token I can update the serialization object to only take that, if you have a way to serialize the entire state let me know.

Once we figure something out will update docs and finalize the PR.