### PR TITLE
Added more resource / message types. Refactored message-poller code.

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-﻿import {EventEmitter} from "events";
+import {EventEmitter} from "events";
 import acceptContactRequest from "./api/accept-contact-request";
 import declineContactRequest from "./api/decline-contact-request";
 import getContact from "./api/get-contact";

--- a/src/lib/connect.ts
+++ b/src/lib/connect.ts
@@ -1,4 +1,4 @@
-﻿import {Incident} from "incident";
+import {Incident} from "incident";
 import * as api from "./api";
 import {Credentials} from "./interfaces/api/api";
 import {Context} from "./interfaces/api/context";

--- a/src/lib/interfaces/api/context.ts
+++ b/src/lib/interfaces/api/context.ts
@@ -1,4 +1,4 @@
-﻿import {CookieJar, MemoryCookieStore, Store as CookieStore} from "tough-cookie";
+import {CookieJar, MemoryCookieStore, Store as CookieStore} from "tough-cookie";
 
 /**
  * Represents the OAuth token used for most calls to the Skype API.

--- a/src/lib/interfaces/api/resources.ts
+++ b/src/lib/interfaces/api/resources.ts
@@ -1,7 +1,15 @@
-import {ParsedConversationId} from "./api";
+import { ParsedConversationId } from "./api";
+export interface CallParticipant {
+  duration?: number;
+  displayName: string;
+  username: string;
+}
 
+export declare type ResourceType = "Text" | "RichText" | "Control/ClearTyping" | "Control/Typing" | "RichText/UriObject"
+  | "RichText/Media_GenericFile" | "Signal/Flamingo" | "Event/Call" | "RichText/Location" | "ConversationUpdate"
+  | "RichText/Media_Video";
 export interface Resource {
-  type: "Text" | "RichText" | "Control/ClearTyping" | "Control/Typing" | "ConversationUpdate" /* | "Typing" | ... */;
+  type: ResourceType;
   id: string;
   composeTime: Date;
   arrivalTime: Date;
@@ -15,11 +23,50 @@ export interface TextResource extends Resource {
   clientId: string; // An id set by the client
   content: string;
 }
-
+export interface RichTextLocationResource extends Resource {
+  latitude: number;
+  longitude: number;
+  altitude: number;
+  speed: number;
+  course: number;
+  address: string;
+  pointOfInterest: string;
+  map_url: string;
+}
+export interface RichTextMediaGenericFileResource extends FileResource {
+  type: "RichText/Media_GenericFile";
+}
+export interface RichTextMediaVideoResource extends FileResource {
+  type: "RichText/Media_Video";
+}
+export interface RichTextUriObjectResource extends FileResource {
+  type: "RichText/UriObject";
+}
+export interface FileResource extends Resource {
+  uri_type: string;
+  uri: string;
+  uri_thumbnail: string;
+  uri_w_login: string;
+  file_size?: number;
+  original_file_name: string;
+}
+export interface EventCallResource extends Resource {
+  event_type: "started" | "ended";
+  duration?: number; // duration of the shorted participant on the call
+  call_connected: boolean; // if it was connected or missed
+  skypeguid: string;
+  participants: CallParticipant[];
+}
 export interface RichTextResource extends Resource {
   type: "RichText";
   clientId: string; // An id set by the client
   content: string;
+}
+
+export interface SignalFlamingoResource extends Resource { // incoming call request
+  type: "Signal/Flamingo";
+  skypeguid: string;
+
 }
 
 export interface ControlClearTypingResource extends Resource {

--- a/src/lib/interfaces/native-api/message-resources.ts
+++ b/src/lib/interfaces/native-api/message-resources.ts
@@ -59,7 +59,11 @@ export interface EventCall extends MessageResource {
   content: string; // XML with root <partlist>
   skypeguid: string; // [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}
 }
-
+export interface SignalFlamingo extends MessageResource {
+  messagetype: "Signal/Flamingo";
+  content: string; // json with then a base64 encoded payload
+  skypeguid: string;
+}
 export interface Text extends MessageResource {
   messagetype: "Text";
   clientmessageid: string; // A large integer (~20 digits)
@@ -71,9 +75,24 @@ export interface RichText extends MessageResource {
   clientmessageid: string; // A large integer (~20 digits)
   content: string; // For example when using smileys: "Hi <ss type=\"smile\">:)</ss>"
 }
-
 export interface UriObject extends MessageResource {
   messagetype: "RichText/UriObject";
+  clientmessageid: string; // A large integer (~20 digits)
+  content: string; // XML, root is <URIObject>
+}
+
+export interface LocationObject extends MessageResource {
+  messagetype: "RichText/Location";
+  clientmessageid: string; // A large integer (~20 digits)
+  content: string; // XML, root is <URIObject>
+}
+export interface MediaGenericFile extends MessageResource {
+  messagetype: "RichText/Media_GenericFile";
+  clientmessageid: string; // A large integer (~20 digits)
+  content: string; // XML, root is <URIObject>
+}
+export interface MediaVideo extends MessageResource {
+  messagetype: "RichText/Media_Video";
   clientmessageid: string; // A large integer (~20 digits)
   content: string; // XML, root is <URIObject>
 }

--- a/src/lib/interfaces/native-api/resources.ts
+++ b/src/lib/interfaces/native-api/resources.ts
@@ -14,7 +14,8 @@ export interface ConversationUpdate extends Resource {
 export interface MessageResource extends Resource {
   type: "Message";
   messagetype: "Control/LiveState" | "Control/ClearTyping" | "Control/Typing" | "Event/Call"
-  | "RichText" | "RichText/UriObject" | "Text" | string; // TODO
+  | "RichText" | "RichText/UriObject" | "RichText/Location" | "RichText/Media_GenericFile"
+  | "RichText/Media_Video" | "Signal/Flamingo" | "Text" | string; // TODO
   ackrequired: string;
   // JSON date
   originalarrivaltime: string;

--- a/src/lib/login.ts
+++ b/src/lib/login.ts
@@ -1,4 +1,4 @@
-﻿import {Incident} from "incident";
+﻿ import {Incident} from "incident";
 import {MemoryCookieStore, Store as CookieStore} from "tough-cookie";
 import {parse as parseUri, Url} from "url";
 import * as Consts from "./consts";

--- a/src/test/polling/message-poller.spec.ts
+++ b/src/test/polling/message-poller.spec.ts
@@ -5,6 +5,7 @@ import * as messagesUri from "../../lib/messages-uri";
 import {
   formatControlClearTypingResource,
   formatControlTypingResource,
+  formatGenericMessageResource,
   parseContactId,
 } from "../../lib/polling/messages-poller";
 
@@ -60,7 +61,8 @@ describe("formatControlClearTypingResource", function () {
 
   for (const item of items) {
     it("should format a Control/ClearTyping Message resource", function () {
-      const actual: resources.ControlClearTypingResource = formatControlClearTypingResource(item.nativeResource);
+      // tslint:disable-next-line:max-line-length
+      const actual: resources.ControlClearTypingResource = formatControlClearTypingResource(formatGenericMessageResource(item.nativeResource, item.nativeResource.messagetype), item.nativeResource);
       const expected: resources.ControlClearTypingResource = item.expectedFormattedResource;
       assert.strictEqual(actual.type, expected.type);
       assert.strictEqual(actual.id, expected.id);
@@ -126,7 +128,8 @@ describe("formatControlTypingResource", function () {
 
   for (const item of items) {
     it("should format a Control/Typing Message resource", function () {
-      const actual: resources.ControlTypingResource = formatControlTypingResource(item.nativeResource);
+      // tslint:disable-next-line:max-line-length
+      const actual: resources.ControlTypingResource = formatControlTypingResource(formatGenericMessageResource(item.nativeResource, item.nativeResource.messagetype), item.nativeResource);
       const expected: resources.ControlTypingResource = item.expectedFormattedResource;
       assert.strictEqual(actual.type, expected.type);
       assert.strictEqual(actual.id, expected.id);


### PR DESCRIPTION
Some minor BOM fixes.

This is somewhat hacky and there may be a better way to do some of it.  The main problem is I wanted to de-dupe all the code for parsing generic resource stuff out (especially as I would need to dupe a lot for these additional types).  Primarily this is the function `formatGenericMessageResource` and `formatFileResource` intermediate parsers.
 I looked at several options, but am open to suggestions as I could not find a great one.  One was change the top level interfaces to classes, so we could construct them without having to specify all args upfront.  This had the downside we would have to re-declare all the interface properties on the class leading to duplicate code there. We could change all of the interfaces (for example Resource, MessageResource, MediaGenericFile ) to classes from the bottom up, this solves having to redeclare interface items.  Without doing classes we cannot partially declare an interface.  To solve this I initialize a generic resource, then cast it to a higher type in each type.  Of course this doesn't stop you from forgetting a parameter that you should be setting, but I don't have a great solution for that (even classes would allow you to not set something).  Classes would also mean you can't use the {} syntax to declare them, but rather set properties manually (unless we made constructors which would be less good given all the args).  One could do an interface containing both the base type and extended properties separately.  IE: MessageResource{resource: Resource; } this is bad as it makes the end user more confused during refactors, and requires them to use sub-interfaces on items for no reason.
 The best option may be converting everything to classes to avoid the odd casting, let me know if you want it refactored this way (or another).

Not sure if we want to rename events? Signal/Flamingo is basically an incoming call notification but is named weirdly...

I left some debug code commented out in there that I generally find myself re-adding often.  Likely a better logging system to allow easier tweaking of debug levels would probably be good (have used bunyan before).

FYI (not sure if documenting this somewhere is a good idea):
An Event/Call event will happen when a call is started (type started) (either accepted by a party or missed) and then when the call is ended (type ended).  This is both for incoming and outgoing calls.  A Signal/Flamingo will happen on an incoming call request (ring basically).  The rest of the types should be fairly obvious.  There may be more, these are the more common ones I saw.