### PR TITLE
Add support for image sending

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/form-data": "0.0.33",
     "@types/lodash": "^4.14.64",
     "@types/request": "0.0.43",
+    "async-file": "^2.0.2",
     "big-integer": "^1.5.6",
     "bluebird": "^3.3.5",
     "cheerio": "^0.19.0",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,6 +5,7 @@ import getContact from "./api/get-contact";
 import getContacts from "./api/get-contacts";
 import getConversation from "./api/get-conversation";
 import getConversations from "./api/get-conversations";
+import sendImage from "./api/send-image";
 import sendMessage from "./api/send-message";
 import setStatus from "./api/set-status";
 import * as api from "./interfaces/api/api";
@@ -57,6 +58,10 @@ export class Api extends EventEmitter implements ApiEvents {
 
   sendMessage(message: api.NewMessage, conversationId: string): Promise<api.SendMessageResult> {
     return sendMessage(this.io, this.context, message, conversationId);
+  }
+
+  sendImage(message: api.NewImage, conversationId: string): Promise<api.SendMessageResult> {
+    return sendImage(this.io, this.context, message, conversationId);
   }
 
   getState(): ApiContext.Json {

--- a/src/lib/api/send-image.ts
+++ b/src/lib/api/send-image.ts
@@ -1,0 +1,105 @@
+import * as fs from "async-file";
+import { Incident } from "incident";
+import * as api from "../interfaces/api/api";
+import { Context } from "../interfaces/api/context";
+import * as io from "../interfaces/http-io";
+import * as messagesUri from "../messages-uri";
+import { getCurrentTime } from "../utils";
+
+interface SendMessageResponse {
+  OriginalArrivalTime: number;
+}
+
+interface SendMessageQuery {
+  clientmessageid: string;
+  content: string;
+  messagetype: string;
+  contenttype: string;
+}
+
+export async function sendImage(
+  io: io.HttpIo, apiContext: Context,
+  img: api.NewImage,
+  conversationId: string,
+): Promise<api.SendMessageResult> {
+  if (!img.file || !img.name) {
+    return Promise.reject(new Incident("send-image", "Invalid parameters"));
+  }
+  const bodyNewObject: any = {
+    type: "pish/image",
+    permissions: {[conversationId]: ["read"]},
+  };
+  const bodyNewObjectStr: string = JSON.stringify(bodyNewObject);
+  const requestOptionsNewObject: io.PostOptions = {
+    uri: messagesUri.objects("api.asm.skype.com"),
+    cookies: apiContext.cookies,
+    body: bodyNewObjectStr,
+    headers: {
+      "Authorization": "skype_token " + apiContext.skypeToken.value,
+      "Content-Type": "application/json",
+      "Content-Length": bodyNewObjectStr.length,
+    },
+  };
+  const resNewObject: io.Response = await io.post(requestOptionsNewObject);
+
+  if (resNewObject.statusCode !== 201) {
+    return Promise.reject(new Incident("send-image", "Received wrong return code"));
+  }
+  const objectId: string = JSON.parse(resNewObject.body).id;
+
+  const file: Buffer = await fs.readFile(img.file);
+  const requestOptionsPutObject: io.PutOptions = {
+    uri: messagesUri.objectContent("api.asm.skype.com", objectId, "imgpsh"),
+    cookies: apiContext.cookies,
+    body: file,
+    headers: {
+      "Authorization": "skype_token " + apiContext.skypeToken.value,
+      "Content-Type": "multipart/form-data",
+      "Content-Length": file.byteLength,
+    },
+  };
+  const resObject: io.Response = await io.put(requestOptionsPutObject);
+
+  if (resObject.statusCode !== 201) {
+    return Promise.reject(new Incident("send-image", "Received wrong return code"));
+  }
+
+  const pictureUri: string = messagesUri.object("api.asm.skype.com", objectId);
+  const pictureThumbnailUri: string = messagesUri.objectView("api.asm.skype.com", objectId, "imgt1");
+
+  const query: SendMessageQuery = {
+    clientmessageid: String(getCurrentTime() + Math.floor(10000 * Math.random())),
+    content: `
+      <URIObject type="Picture.1" uri="${pictureUri}" url_thumbnail="${pictureThumbnailUri}">
+        loading...
+        <OriginalName v="${img.name}"/>
+        <meta type="photo" originalName="${img.name}"/>
+      </URIObject>
+    `,
+    messagetype: "RichText/UriObject",
+    contenttype: "text",
+  };
+  const requestOptions: io.PostOptions = {
+    uri: messagesUri.messages(apiContext.registrationToken.host, messagesUri.DEFAULT_USER, conversationId),
+    cookies: apiContext.cookies,
+    body: JSON.stringify(query),
+    headers: {
+      RegistrationToken: apiContext.registrationToken.raw,
+    },
+  };
+  const res: io.Response = await io.post(requestOptions);
+
+  if (res.statusCode !== 201) {
+    return Promise.reject(new Incident("send-message", "Received wrong return code"));
+  }
+  const parsed: messagesUri.MessageUri = messagesUri.parseMessage(res.headers["location"]);
+  const body: SendMessageResponse = JSON.parse(res.body);
+  return {
+    clientMessageId: query.clientmessageid,
+    arrivalTime: body.OriginalArrivalTime,
+    textContent: query.content,
+    MessageId: parsed.message,
+  };
+}
+
+export default sendImage;

--- a/src/lib/interfaces/api/api.ts
+++ b/src/lib/interfaces/api/api.ts
@@ -26,6 +26,11 @@ export interface NewMessage {
   textContent: string;
 }
 
+export interface NewImage {
+  file: string;
+  name: string;
+}
+
 export interface ParsedId {
   id: string;
   typeKey: string;

--- a/src/lib/messages-uri.ts
+++ b/src/lib/messages-uri.ts
@@ -101,6 +101,26 @@ function buildUserMessagingService(user: string): string[] {
   return buildUserPresenceDocs(user).concat("endpointMessagingService");
 }
 
+// /v1/objects
+function buildObjects(): string[] {
+  return buildV1().concat("objects");
+}
+
+// /v1/objects/{objectId}
+function buildObject(objectId: string) {
+  return buildObjects().concat(objectId);
+}
+
+// /v1/objects/{objectId}/content/{content}
+function buildObjectContent(objectId: string, content: string) {
+  return buildObject(objectId).concat("content").concat(content);
+}
+
+// /v1/objects/{objectId}/view/{content}
+function buildObjectView(objectId: string, view: string) {
+  return buildObject(objectId).concat("view").concat(view);
+}
+
 /**
  * Returns an URI origin like: "https://host.com"
  * If host is `null`, returns an empty string
@@ -167,6 +187,22 @@ export function conversation(host: string, user: string, conversationId: string)
  */
 export function messages(host: string, user: string, conversationId: string): string {
   return get(host, joinPath(buildMessages(user, conversationId)));
+}
+
+export function objects(host: string): string {
+  return get(host, joinPath(buildObjects()));
+}
+
+export function object(host: string, objectId: string): string {
+  return get(host, joinPath(buildObject(objectId)));
+}
+
+export function objectContent(host: string, objectId: string, content: string): string {
+  return get(host, joinPath(buildObjectContent(objectId, content)));
+}
+
+export function objectView(host: string, objectId: string, view: string): string {
+  return get(host, joinPath(buildObjectView(objectId, view)));
 }
 
 export function userMessagingService(host: string, user: string = DEFAULT_USER): string {


### PR DESCRIPTION
This commit adds the new `sendMessage` method to send an
image. It requires the path for the image and the conversation ID.

---

This PR supersedes #46 by @Sorunome. I just fixed the few linting issues (missing types and line length) and squashed the commits.