### PR TITLE
Use contacts API v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Next
 
+- **[Breaking change]** Use contacts API v2: the new types are in `lib/types`, the old types
+    remain in `lib/interfaces`. The main difference is that the MRI key (`8:user_id`) is no longer
+    parsed and most of the contact details are now in a `Profile` object.
+    It is no longer possible to get a single contact.
 - **[Feature]** Expose detailed errors for endpoint registration.
 - **[Feature]** Support ES modules (ESM)
 - **[Internal]** Update project tools to [turbo-gulp](https://www.npmjs.com/package/turbo-gulp)
 - **[Internal]** Enable integration with Codecov
 - **[Internal]** Enable integration with Greenkeeper
+- **[Internal]** Use runtime representation of the types with Kryo
 
 # 0.0.13 (2017-07-16)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,14 @@
         "through2": "2.0.3"
       }
     },
+    "@types/bson": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-1.0.6.tgz",
+      "integrity": "sha512-v7N8qcTGiYhLRyi+Y69R3tPC4GLqByCg3NC2EO6PciC166O9dNhjFPoXeMePtZ+0f+/O2xLDWXs5BLnRfcBaBA==",
+      "requires": {
+        "@types/node": "9.3.0"
+      }
+    },
     "@types/chai": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.0.tgz",
@@ -323,6 +331,11 @@
       "resolved": "https://registry.npmjs.org/@types/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
       "integrity": "sha512-Z4TYuEKn9+RbNVk1Ll2SS4x1JeLHecolIbM/a8gveaHsW0Hr+RQMraZACwTO2VD7JvepgA6UO1A1VrbktQrIbQ==",
       "dev": true
+    },
+    "@types/unorm": {
+      "version": "1.3.27",
+      "resolved": "https://registry.npmjs.org/@types/unorm/-/unorm-1.3.27.tgz",
+      "integrity": "sha1-YL2zuy5cnr5tCC3zoTypkjAsyno="
     },
     "@types/vinyl": {
       "version": "2.0.2",
@@ -1054,6 +1067,12 @@
       "requires": {
         "pako": "1.0.6"
       }
+    },
+    "bson": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
+      "integrity": "sha1-k8ENOeqltYQVy8QFLz5T5WKwtyw=",
+      "optional": true
     },
     "buffer": {
       "version": "4.9.1",
@@ -4997,6 +5016,20 @@
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
       "dev": true
     },
+    "kryo": {
+      "version": "0.6.0-build.161",
+      "resolved": "https://registry.npmjs.org/kryo/-/kryo-0.6.0-build.161.tgz",
+      "integrity": "sha512-XGVhUNar0usZjT+J7yh+YxcX3Le7OxKIJFq0HViImU/LMuGKxt5kZHF8Tft9NHtrVJoURJXuwdm7n0+P4MUZQQ==",
+      "requires": {
+        "@types/bson": "1.0.6",
+        "@types/object-inspect": "1.4.0",
+        "@types/unorm": "1.3.27",
+        "bson": "1.0.4",
+        "incident": "3.1.0",
+        "object-inspect": "1.5.0",
+        "unorm": "1.4.1"
+      }
+    },
     "last-run": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
@@ -6046,7 +6079,8 @@
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
           "requires": {
             "kind-of": "3.2.2",
@@ -6056,22 +6090,26 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
           "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "append-transform": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
           "dev": true,
           "requires": {
             "default-require-extensions": "1.0.0"
@@ -6079,12 +6117,14 @@
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "arr-diff": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
             "arr-flatten": "1.1.0"
@@ -6092,27 +6132,32 @@
         },
         "arr-flatten": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+          "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
           "dev": true
         },
         "array-unique": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         },
         "async": {
           "version": "1.5.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "babel-code-frame": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -6122,7 +6167,8 @@
         },
         "babel-generator": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+          "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
           "dev": true,
           "requires": {
             "babel-messages": "6.23.0",
@@ -6137,7 +6183,8 @@
         },
         "babel-messages": {
           "version": "6.23.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
             "babel-runtime": "6.26.0"
@@ -6145,7 +6192,8 @@
         },
         "babel-runtime": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
             "core-js": "2.5.3",
@@ -6154,7 +6202,8 @@
         },
         "babel-template": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
@@ -6166,7 +6215,8 @@
         },
         "babel-traverse": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
             "babel-code-frame": "6.26.0",
@@ -6182,7 +6232,8 @@
         },
         "babel-types": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
@@ -6193,17 +6244,20 @@
         },
         "babylon": {
           "version": "6.18.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
             "balanced-match": "1.0.0",
@@ -6212,7 +6266,8 @@
         },
         "braces": {
           "version": "1.8.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
             "expand-range": "1.8.2",
@@ -6222,12 +6277,14 @@
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
           "dev": true
         },
         "caching-transform": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
+          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
           "dev": true,
           "requires": {
             "md5-hex": "1.3.0",
@@ -6237,13 +6294,15 @@
         },
         "camelcase": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true,
           "optional": true
         },
         "center-align": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6253,7 +6312,8 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
             "ansi-styles": "2.2.1",
@@ -6265,7 +6325,8 @@
         },
         "cliui": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6276,7 +6337,8 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
               "dev": true,
               "optional": true
             }
@@ -6284,32 +6346,38 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "commondir": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "convert-source-map": {
           "version": "1.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
           "dev": true
         },
         "core-js": {
           "version": "2.5.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
           "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
             "lru-cache": "4.1.1",
@@ -6318,7 +6386,8 @@
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -6326,17 +6395,20 @@
         },
         "debug-log": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
           "dev": true,
           "requires": {
             "strip-bom": "2.0.0"
@@ -6344,7 +6416,8 @@
         },
         "detect-indent": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "dev": true,
           "requires": {
             "repeating": "2.0.1"
@@ -6352,7 +6425,8 @@
         },
         "error-ex": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
           "dev": true,
           "requires": {
             "is-arrayish": "0.2.1"
@@ -6360,17 +6434,20 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "esutils": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
             "cross-spawn": "5.1.0",
@@ -6384,7 +6461,8 @@
           "dependencies": {
             "cross-spawn": {
               "version": "5.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
               "dev": true,
               "requires": {
                 "lru-cache": "4.1.1",
@@ -6396,7 +6474,8 @@
         },
         "expand-brackets": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
             "is-posix-bracket": "0.1.1"
@@ -6404,7 +6483,8 @@
         },
         "expand-range": {
           "version": "1.8.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
           "dev": true,
           "requires": {
             "fill-range": "2.2.3"
@@ -6412,7 +6492,8 @@
         },
         "extglob": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
             "is-extglob": "1.0.0"
@@ -6420,12 +6501,14 @@
         },
         "filename-regex": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+          "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
           "dev": true
         },
         "fill-range": {
           "version": "2.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
           "dev": true,
           "requires": {
             "is-number": "2.1.0",
@@ -6437,7 +6520,8 @@
         },
         "find-cache-dir": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "dev": true,
           "requires": {
             "commondir": "1.0.1",
@@ -6447,7 +6531,8 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
             "locate-path": "2.0.0"
@@ -6455,12 +6540,14 @@
         },
         "for-in": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
           "dev": true
         },
         "for-own": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
           "dev": true,
           "requires": {
             "for-in": "1.0.2"
@@ -6468,7 +6555,8 @@
         },
         "foreground-child": {
           "version": "1.5.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
           "dev": true,
           "requires": {
             "cross-spawn": "4.0.2",
@@ -6477,22 +6565,26 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
           "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -6505,7 +6597,8 @@
         },
         "glob-base": {
           "version": "0.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+          "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
           "dev": true,
           "requires": {
             "glob-parent": "2.0.0",
@@ -6514,7 +6607,8 @@
         },
         "glob-parent": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
             "is-glob": "2.0.1"
@@ -6522,17 +6616,20 @@
         },
         "globals": {
           "version": "9.18.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
           "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "handlebars": {
           "version": "4.0.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+          "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
           "dev": true,
           "requires": {
             "async": "1.5.2",
@@ -6543,7 +6640,8 @@
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "dev": true,
               "requires": {
                 "amdefine": "1.0.1"
@@ -6553,7 +6651,8 @@
         },
         "has-ansi": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -6561,22 +6660,26 @@
         },
         "has-flag": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "1.4.0",
@@ -6585,12 +6688,14 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "invariant": {
           "version": "2.2.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+          "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "dev": true,
           "requires": {
             "loose-envify": "1.3.1"
@@ -6598,22 +6703,26 @@
         },
         "invert-kv": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
           "dev": true
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
           "dev": true
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
           "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "dev": true,
           "requires": {
             "builtin-modules": "1.1.1"
@@ -6621,12 +6730,14 @@
         },
         "is-dotfile": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+          "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
           "dev": true
         },
         "is-equal-shallow": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+          "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
           "dev": true,
           "requires": {
             "is-primitive": "2.0.0"
@@ -6634,17 +6745,20 @@
         },
         "is-extendable": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
           "dev": true
         },
         "is-extglob": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "is-finite": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -6652,7 +6766,8 @@
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -6660,7 +6775,8 @@
         },
         "is-glob": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
             "is-extglob": "1.0.0"
@@ -6668,7 +6784,8 @@
         },
         "is-number": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
             "kind-of": "3.2.2"
@@ -6676,37 +6793,44 @@
         },
         "is-posix-bracket": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+          "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
           "dev": true
         },
         "is-primitive": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "is-utf8": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "isobject": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
           "dev": true,
           "requires": {
             "isarray": "1.0.0"
@@ -6714,12 +6838,14 @@
         },
         "istanbul-lib-coverage": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+          "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
           "dev": true
         },
         "istanbul-lib-hook": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
+          "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
           "dev": true,
           "requires": {
             "append-transform": "0.4.0"
@@ -6727,7 +6853,8 @@
         },
         "istanbul-lib-instrument": {
           "version": "1.9.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz",
+          "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
           "dev": true,
           "requires": {
             "babel-generator": "6.26.0",
@@ -6741,7 +6868,8 @@
         },
         "istanbul-lib-report": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
+          "integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
           "dev": true,
           "requires": {
             "istanbul-lib-coverage": "1.1.1",
@@ -6752,7 +6880,8 @@
           "dependencies": {
             "supports-color": {
               "version": "3.2.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
               "dev": true,
               "requires": {
                 "has-flag": "1.0.0"
@@ -6762,7 +6891,8 @@
         },
         "istanbul-lib-source-maps": {
           "version": "1.2.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
+          "integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
           "dev": true,
           "requires": {
             "debug": "3.1.0",
@@ -6774,7 +6904,8 @@
           "dependencies": {
             "debug": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
               "dev": true,
               "requires": {
                 "ms": "2.0.0"
@@ -6784,7 +6915,8 @@
         },
         "istanbul-reports": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.3.tgz",
+          "integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
           "dev": true,
           "requires": {
             "handlebars": "4.0.11"
@@ -6792,17 +6924,20 @@
         },
         "js-tokens": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
           "dev": true
         },
         "jsesc": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
             "is-buffer": "1.1.6"
@@ -6810,13 +6945,15 @@
         },
         "lazy-cache": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
           "dev": true,
           "optional": true
         },
         "lcid": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "dev": true,
           "requires": {
             "invert-kv": "1.0.0"
@@ -6824,7 +6961,8 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -6836,7 +6974,8 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
             "p-locate": "2.0.0",
@@ -6845,24 +6984,28 @@
           "dependencies": {
             "path-exists": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
               "dev": true
             }
           }
         },
         "lodash": {
           "version": "4.17.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
           "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "dev": true,
           "requires": {
             "js-tokens": "3.0.2"
@@ -6870,7 +7013,8 @@
         },
         "lru-cache": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -6879,7 +7023,8 @@
         },
         "md5-hex": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "dev": true,
           "requires": {
             "md5-o-matic": "0.1.1"
@@ -6887,12 +7032,14 @@
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
           "dev": true
         },
         "mem": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
           "dev": true,
           "requires": {
             "mimic-fn": "1.1.0"
@@ -6900,7 +7047,8 @@
         },
         "merge-source-map": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+          "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
           "dev": true,
           "requires": {
             "source-map": "0.5.7"
@@ -6908,7 +7056,8 @@
         },
         "micromatch": {
           "version": "2.3.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
             "arr-diff": "2.0.0",
@@ -6928,12 +7077,14 @@
         },
         "mimic-fn": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+          "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.8"
@@ -6941,12 +7092,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -6954,12 +7107,14 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "dev": true,
           "requires": {
             "hosted-git-info": "2.5.0",
@@ -6970,7 +7125,8 @@
         },
         "normalize-path": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
             "remove-trailing-separator": "1.1.0"
@@ -6978,7 +7134,8 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
             "path-key": "2.0.1"
@@ -6986,17 +7143,20 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "object.omit": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
           "dev": true,
           "requires": {
             "for-own": "0.1.5",
@@ -7005,7 +7165,8 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -7013,7 +7174,8 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8",
@@ -7022,12 +7184,14 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
             "execa": "0.7.0",
@@ -7037,17 +7201,20 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-limit": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+          "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
           "dev": true
         },
         "p-locate": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
             "p-limit": "1.1.0"
@@ -7055,7 +7222,8 @@
         },
         "parse-glob": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+          "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
           "dev": true,
           "requires": {
             "glob-base": "0.3.0",
@@ -7066,7 +7234,8 @@
         },
         "parse-json": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
             "error-ex": "1.3.1"
@@ -7074,7 +7243,8 @@
         },
         "path-exists": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
             "pinkie-promise": "2.0.1"
@@ -7082,22 +7252,26 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-parse": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
           "dev": true
         },
         "path-type": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -7107,17 +7281,20 @@
         },
         "pify": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
           "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
             "pinkie": "2.0.4"
@@ -7125,7 +7302,8 @@
         },
         "pkg-dir": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
             "find-up": "1.1.2"
@@ -7133,7 +7311,8 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
                 "path-exists": "2.1.0",
@@ -7144,17 +7323,20 @@
         },
         "preserve": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+          "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "randomatic": {
           "version": "1.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+          "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
           "dev": true,
           "requires": {
             "is-number": "3.0.0",
@@ -7163,7 +7345,8 @@
           "dependencies": {
             "is-number": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
@@ -7171,7 +7354,8 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
                     "is-buffer": "1.1.6"
@@ -7181,7 +7365,8 @@
             },
             "kind-of": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "dev": true,
               "requires": {
                 "is-buffer": "1.1.6"
@@ -7191,7 +7376,8 @@
         },
         "read-pkg": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
             "load-json-file": "1.1.0",
@@ -7201,7 +7387,8 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
             "find-up": "1.1.2",
@@ -7210,7 +7397,8 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
                 "path-exists": "2.1.0",
@@ -7221,12 +7409,14 @@
         },
         "regenerator-runtime": {
           "version": "0.11.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
           "dev": true
         },
         "regex-cache": {
           "version": "0.4.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+          "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
           "dev": true,
           "requires": {
             "is-equal-shallow": "0.1.3"
@@ -7234,22 +7424,26 @@
         },
         "remove-trailing-separator": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+          "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
           "dev": true
         },
         "repeat-element": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
           "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
           "dev": true
         },
         "repeating": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "dev": true,
           "requires": {
             "is-finite": "1.0.2"
@@ -7257,22 +7451,26 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
           "dev": true
         },
         "right-align": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7281,7 +7479,8 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
             "glob": "7.1.2"
@@ -7289,17 +7488,20 @@
         },
         "semver": {
           "version": "5.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
             "shebang-regex": "1.0.0"
@@ -7307,27 +7509,32 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+          "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
           "dev": true,
           "requires": {
             "foreground-child": "1.5.6",
@@ -7340,7 +7547,8 @@
         },
         "spdx-correct": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
           "dev": true,
           "requires": {
             "spdx-license-ids": "1.2.2"
@@ -7348,17 +7556,20 @@
         },
         "spdx-expression-parse": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
           "dev": true
         },
         "spdx-license-ids": {
           "version": "1.2.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -7367,17 +7578,20 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "3.0.0"
@@ -7387,7 +7601,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -7395,7 +7610,8 @@
         },
         "strip-bom": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
             "is-utf8": "0.2.1"
@@ -7403,17 +7619,20 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "test-exclude": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
+          "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
           "dev": true,
           "requires": {
             "arrify": "1.0.1",
@@ -7425,17 +7644,20 @@
         },
         "to-fast-properties": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
           "dev": true
         },
         "trim-right": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
           "dev": true
         },
         "uglify-js": {
           "version": "2.8.29",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7446,7 +7668,8 @@
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7460,13 +7683,15 @@
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
           "dev": true,
           "optional": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
           "dev": true,
           "requires": {
             "spdx-correct": "1.0.2",
@@ -7475,7 +7700,8 @@
         },
         "which": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
             "isexe": "2.0.0"
@@ -7483,23 +7709,27 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "window-size": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
           "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
             "string-width": "1.0.2",
@@ -7508,7 +7738,8 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
@@ -7520,12 +7751,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.3.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -7535,17 +7768,20 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         },
         "yargs": {
           "version": "10.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+          "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
           "dev": true,
           "requires": {
             "cliui": "3.2.0",
@@ -7564,7 +7800,8 @@
           "dependencies": {
             "cliui": {
               "version": "3.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
               "dev": true,
               "requires": {
                 "string-width": "1.0.2",
@@ -7574,7 +7811,8 @@
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
                   "requires": {
                     "code-point-at": "1.1.0",
@@ -7588,7 +7826,8 @@
         },
         "yargs-parser": {
           "version": "8.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+          "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
           "dev": true,
           "requires": {
             "camelcase": "4.1.0"
@@ -7596,7 +7835,8 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             }
           }
@@ -10040,6 +10280,12 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
       "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
       "dev": true
+    },
+    "unorm": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.4.1.tgz",
+      "integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA=",
+      "optional": true
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prepare": "gulp all:tsconfig.json && gulp :tslint.json && gulp dist",
     "prestart": "gulp example:build",
     "start": "node --experimental-modules build/example/example/main.js",
-    "pretest": "gulp lib:build",
+    "pretest": "gulp :lint && gulp lib:build",
     "test": "gulp test",
     "test-online": "OCILO_TEST_ONLINE=true npm test",
     "prepublishOnly": "npm run test-online",
@@ -41,6 +41,7 @@
     "cheerio": "^1.0.0-rc.2",
     "incident": "^3.1.0",
     "js-sha256": "^0.9.0",
+    "kryo": "^0.6.0-build.161",
     "lodash": "^4.17.4",
     "request": "^2.83.0",
     "tough-cookie": "^2.3.3"

--- a/src/example/main.ts
+++ b/src/example/main.ts
@@ -2,13 +2,12 @@ import fs from "fs";
 import path from "path";
 import readline from "readline";
 import { Api as SkypeApi } from "../lib/api";
-import { VIRTUAL_CONTACTS } from "../lib/api/get-contact";
 import * as skypeHttp from "../lib/connect";
 import { Credentials } from "../lib/interfaces/api/api";
-import { Contact } from "../lib/interfaces/api/contact";
 import { Context } from "../lib/interfaces/api/context";
 import * as events from "../lib/interfaces/api/events";
 import * as resources from "../lib/interfaces/api/resources";
+import { Contact } from "../lib/types/contact";
 import meta from "./meta.js";
 
 /**
@@ -98,18 +97,6 @@ async function runExample(): Promise<void> {
   const contacts: Contact[] = await api.getContacts();
   console.log("Your contacts:");
   console.log(JSON.stringify(contacts, null, 2));
-
-  await Promise.all(contacts.map(async function (contact: Contact) {
-    try {
-      if (VIRTUAL_CONTACTS.has(contact.id.id)) {
-        return;
-      }
-      const fullContact: Contact = await api.getContact(contact.id.id);
-      console.log(JSON.stringify(fullContact, null, 2));
-    } catch (err) {
-      console.warn(err);
-    }
-  }));
 
   console.log("Starting polling:");
   await api.listen();

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,19 +2,21 @@ import events from "events";
 import { acceptContactRequest } from "./api/accept-contact-request";
 import { declineContactRequest } from "./api/decline-contact-request";
 import { getContact } from "./api/get-contact";
-import { getContacts } from "./api/get-contacts";
 import { getConversation } from "./api/get-conversation";
 import { getConversations } from "./api/get-conversations";
 import { sendImage } from "./api/send-image";
 import { sendMessage } from "./api/send-message";
 import { setStatus } from "./api/set-status";
+import { ContactsInterface, ContactsService } from "./contacts/contacts";
 import * as api from "./interfaces/api/api";
-import { Contact } from "./interfaces/api/contact";
+import { Contact as _Contact } from "./interfaces/api/contact";
 import { Context as ApiContext } from "./interfaces/api/context";
 import { Conversation } from "./interfaces/api/conversation";
 import * as apiEvents from "./interfaces/api/events";
 import { HttpIo } from "./interfaces/http-io";
 import { MessagesPoller } from "./polling/messages-poller";
+import { Contact } from "./types/contact";
+import { Invite } from "./types/invite";
 
 export interface ApiEvents extends NodeJS.EventEmitter {
 
@@ -25,6 +27,8 @@ export class Api extends events.EventEmitter implements ApiEvents {
   context: ApiContext;
   messagesPoller: MessagesPoller;
 
+  private readonly contactsService: ContactsInterface;
+
   constructor(context: ApiContext, io: HttpIo) {
     super();
     this.context = context;
@@ -33,6 +37,7 @@ export class Api extends events.EventEmitter implements ApiEvents {
     this.messagesPoller.on("error", (err: Error) => this.emit("error", err));
     // tslint:disable-next-line:no-void-expression
     this.messagesPoller.on("event-message", (ev: apiEvents.EventMessage) => this.handlePollingEvent(ev));
+    this.contactsService = new ContactsService(this.io);
   }
 
   async acceptContactRequest(contactUsername: string): Promise<this> {
@@ -45,12 +50,22 @@ export class Api extends events.EventEmitter implements ApiEvents {
     return this;
   }
 
-  async getContact(contactId: string): Promise<Contact> {
+  async getContactInvites(): Promise<Invite[]> {
+    return this.contactsService.getInvites(this.context);
+  }
+
+  /**
+   * Returns a single legacy contact.
+   *
+   * @deprecated Use `getContacts` and filter yourself. We should implement `getProfile` as a
+   *             replacement.
+   */
+  async getContact(contactId: string): Promise<_Contact> {
     return getContact(this.io, this.context, contactId);
   }
 
   async getContacts(): Promise<Contact[]> {
-    return getContacts(this.io, this.context);
+    return this.contactsService.getContacts(this.context);
   }
 
   async getConversation(conversationId: string): Promise<Conversation> {

--- a/src/lib/api/get-conversation.ts
+++ b/src/lib/api/get-conversation.ts
@@ -20,7 +20,7 @@ interface ConversationBody {
 }
 
 interface GetConversationQuery {
-  startTime: number; // a timestamp ?
+  startTime: string; // a timestamp ?
   view: "msnp24Equivalent" | string;
   targetType: string; // seen: Passport|Skype|Lync|Thread
 }
@@ -31,7 +31,7 @@ export async function getConversation(
   conversationId: string,
 ): Promise<Conversation> {
   const query: GetConversationQuery = {
-    startTime: 0,
+    startTime: "0",
     view: "msnp24Equivalent",
     targetType: "Passport|Skype|Lync|Thread",
   };

--- a/src/lib/api/get-conversations.ts
+++ b/src/lib/api/get-conversations.ts
@@ -18,14 +18,14 @@ interface ConversationsBody {
 }
 
 interface GetConversationsQuery {
-  startTime: number; // a timestamp ?
+  startTime: string; // a timestamp ?
   view: "msnp24Equivalent" | string;
   targetType: string; // seen: Passport|Skype|Lync|Thread
 }
 
 export async function getConversations(io: io.HttpIo, apiContext: Context): Promise<Conversation[]> {
   const query: GetConversationsQuery = {
-    startTime: 0,
+    startTime: "0",
     view: "msnp24Equivalent",
     targetType: "Passport|Skype|Lync|Thread",
   };

--- a/src/lib/api/send-image.ts
+++ b/src/lib/api/send-image.ts
@@ -32,9 +32,9 @@ export async function sendImage(
     cookies: apiContext.cookies,
     body: bodyNewObjectStr,
     headers: {
-      "Authorization": "skype_token " + apiContext.skypeToken.value,
+      "Authorization": `skype_token ${apiContext.skypeToken.value}`,
       "Content-Type": "application/json",
-      "Content-Length": bodyNewObjectStr.length,
+      "Content-Length": bodyNewObjectStr.length.toString(10),
     },
   };
   const resNewObject: io.Response = await io.post(requestOptionsNewObject);
@@ -50,9 +50,9 @@ export async function sendImage(
     cookies: apiContext.cookies,
     body: file,
     headers: {
-      "Authorization": "skype_token " + apiContext.skypeToken.value,
+      "Authorization": `skype_token ${apiContext.skypeToken.value}`,
       "Content-Type": "multipart/form-data",
-      "Content-Length": file.byteLength,
+      "Content-Length": file.byteLength.toString(10),
     },
   };
   const resObject: io.Response = await io.put(requestOptionsPutObject);

--- a/src/lib/contacts/api/get-invites.ts
+++ b/src/lib/contacts/api/get-invites.ts
@@ -1,0 +1,21 @@
+import { CaseStyle } from "kryo/case-style";
+import { ArrayType } from "kryo/types/array";
+import { DocumentType } from "kryo/types/document";
+import { $Invite, Invite } from "../../types/invite";
+
+/**
+ * @internal
+ */
+export interface GetInvitesResult {
+  inviteList: Invite[];
+}
+
+/**
+ * @internal
+ */
+export const $GetInvitesResult: DocumentType<GetInvitesResult> = new DocumentType<GetInvitesResult>({
+  properties: {
+    inviteList: {type: new ArrayType({itemType: $Invite, maxLength: Infinity})},
+  },
+  rename: CaseStyle.SnakeCase,
+});

--- a/src/lib/contacts/api/get-user.ts
+++ b/src/lib/contacts/api/get-user.ts
@@ -1,0 +1,34 @@
+import { CaseStyle } from "kryo/case-style";
+import { ArrayType } from "kryo/types/array";
+import { DocumentType } from "kryo/types/document";
+import { JsonType } from "kryo/types/json";
+import { Ucs2StringType } from "kryo/types/ucs2-string";
+import { $Contact, Contact } from "../../types/contact";
+import { $ContactGroup, ContactGroup } from "../../types/contact-group";
+
+/**
+ * @internal
+ */
+export interface GetUserResult {
+  contacts: Contact[];
+  // TODO(demurgos): Rename to `blockList`?
+  blocklist: any[];
+  groups: ContactGroup[];
+  /**
+   * `"full" | ...`
+   */
+  scope: string;
+}
+
+/**
+ * @internal
+ */
+export const $GetUserResult: DocumentType<GetUserResult> = new DocumentType<GetUserResult>({
+  properties: {
+    contacts: {type: new ArrayType({itemType: $Contact, maxLength: Infinity})},
+    blocklist: {type: new ArrayType({itemType: new JsonType(), maxLength: Infinity})},
+    groups: {type: new ArrayType({itemType: $ContactGroup, maxLength: Infinity})},
+    scope: {type: new Ucs2StringType({maxLength: Infinity})},
+  },
+  rename: CaseStyle.SnakeCase,
+});

--- a/src/lib/contacts/contacts-url.ts
+++ b/src/lib/contacts/contacts-url.ts
@@ -1,0 +1,22 @@
+import { Url } from "../types/url";
+
+import path from "path";
+import url from "url";
+
+const CONTACTS_HOST: string = "contacts.skype.com";
+
+export function formatInvites(userId: string): Url {
+  return url.format({
+    protocol: "https",
+    host: CONTACTS_HOST,
+    pathname: path.posix.join("contacts", "v2", "users", userId, "invites"),
+  });
+}
+
+export function formatUser(userId: string): Url {
+  return url.format({
+    protocol: "https",
+    host: CONTACTS_HOST,
+    pathname: path.posix.join("contacts", "v2", "users", userId),
+  });
+}

--- a/src/lib/contacts/contacts.ts
+++ b/src/lib/contacts/contacts.ts
@@ -1,0 +1,87 @@
+import { Incident } from "incident";
+import { UnexpectedHttpStatusError } from "../errors/http";
+import { Context } from "../interfaces/api/context";
+import * as io from "../interfaces/http-io";
+import { Contact } from "../types/contact";
+import { Invite } from "../types/invite";
+import { Url } from "../types/url";
+import { $GetInvitesResult, GetInvitesResult } from "./api/get-invites";
+import { $GetUserResult, GetUserResult } from "./api/get-user";
+import * as contactsUrl from "./contacts-url";
+
+export interface ContactsInterface {
+  /**
+   * Get the pending incoming contact invitations.
+   *
+   * @param apiContext Current API context: with the skype token, cookies and username
+   * @return The list of currently pending incoming contact invitations.
+   */
+  getInvites(apiContext: Context): Promise<Invite[]>;
+
+  /**
+   * Get the contacts of the current user.
+   *
+   * @param apiContext Current API context: with the skype token, cookies and username
+   * @return The list of contacts.
+   */
+  getContacts(apiContext: Context): Promise<Contact[]>;
+}
+
+/**
+ * @internal
+ */
+export class ContactsService {
+  private readonly httpIo: io.HttpIo;
+
+  constructor(httpIo: io.HttpIo) {
+    this.httpIo = httpIo;
+  }
+
+  async getInvites(apiContext: Context): Promise<Invite[]> {
+    const url: Url = contactsUrl.formatInvites(apiContext.username);
+    const request: io.GetOptions = {
+      uri: url,
+      cookies: apiContext.cookies,
+      headers: {
+        "X-Skypetoken": apiContext.skypeToken.value,
+      },
+    };
+    const response: io.Response = await this.httpIo.get(request);
+    if (response.statusCode !== 200) {
+      UnexpectedHttpStatusError.create(response, new Set([200]), request);
+    }
+    let parsed: any;
+    try {
+      parsed = JSON.parse(response.body);
+    } catch (err) {
+      throw new Incident(err, "UnexpectedResponseBody", {body: response.body});
+    }
+    const result: GetInvitesResult = $GetInvitesResult.readJson(parsed);
+    return result.inviteList;
+  }
+
+  async getContacts(apiContext: Context): Promise<Contact[]> {
+    const url: Url = contactsUrl.formatUser(apiContext.username);
+    const request: io.GetOptions = {
+      uri: url,
+      queryString: {page_size: "100", reason: "default"},
+      cookies: apiContext.cookies,
+      headers: {
+        "X-Skypetoken": apiContext.skypeToken.value,
+      },
+    };
+    const response: io.Response = await this.httpIo.get(request);
+    if (response.statusCode !== 200) {
+      UnexpectedHttpStatusError.create(response, new Set([200]), request);
+    }
+    let parsed: any;
+    try {
+      parsed = JSON.parse(response.body);
+    } catch (err) {
+      throw new Incident(err, "UnexpectedResponseBody", {body: response.body});
+    }
+    const result: GetUserResult = $GetUserResult.readJson(parsed);
+    // TODO: Expose the other properties.
+    return result.contacts;
+  }
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -10,6 +10,7 @@ import * as nativeConversation from "./interfaces/native-api/conversation";
 import * as nativeEvents from "./interfaces/native-api/events";
 import * as nativeMessageResources from "./interfaces/native-api/message-resources";
 import * as nativeResources from "./interfaces/native-api/resources";
+import { Location as _Location } from "./types/location";
 
 export { connect, ConnectOptions } from "./connect";
 export { events };
@@ -30,7 +31,7 @@ export type Contact = contact.Contact;
 export namespace Contact {
   export type Contact = contact.Contact;
   export type Phone = contact.Phone;
-  export type Location = contact.Location;
+  export type Location = _Location;
 }
 
 export type Conversation = conversation.Conversation;

--- a/src/lib/interfaces/api/contact.ts
+++ b/src/lib/interfaces/api/contact.ts
@@ -1,10 +1,5 @@
-import { Nullable } from "../utils";
+import { Location } from "../../types/location";
 import { FullId } from "./api";
-
-export interface Location {
-  country: string; // almost certainly an enum...
-  city?: string;
-}
 
 export interface Phone {
   number: string; // pattern: /^+\d+$/  (with country code)
@@ -12,6 +7,7 @@ export interface Phone {
 }
 
 export interface Contact {
+  // TODO: Use MriKey
   id: FullId;
   avatarUrl: string | null;
   phones: Phone[];
@@ -19,8 +15,8 @@ export interface Contact {
   name: {
     first: string | null;
     surname: string | null;
-  nickname: string;
-  displayName: string;
+    nickname: string;
+    displayName: string;
   };
   activityMessage: string | null;
   locations: Location[];
@@ -29,19 +25,19 @@ export interface Contact {
 export interface Profile {
   fistname: string;
   lastname: string;
-  birthday: Nullable<any>;
+  birthday: any | null;
   language: "en" | string; // enum ?
   country: "us" | string; // enum ?
-  province: Nullable<any>;
-  city: Nullable<any>;
-  homepage: Nullable<any>;
-  about: Nullable<any>;
+  province: any | null;
+  city: any | null;
+  homepage: any | null;
+  about: any | null;
   emails: any[];
-  phoneMobile: Nullable<any>;
-  phoneHome: Nullable<any>;
-  phoneOffice: Nullable<any>;
-  mood: Nullable<any>;
-  richMood: Nullable<any>;
-  avatarUrl: Nullable<any>;
+  phoneMobile: any | null;
+  phoneHome: any | null;
+  phoneOffice: any | null;
+  mood: any | null;
+  richMood: any | null;
+  avatarUrl: any | null;
   username: string;
 }

--- a/src/lib/interfaces/http-io.ts
+++ b/src/lib/interfaces/http-io.ts
@@ -1,11 +1,10 @@
 import { Store as CookieStore } from "tough-cookie";
-import { Dictionary } from "./utils";
 
 export interface BaseOptions {
   uri: string;
   cookies?: CookieStore;
-  headers?: Dictionary<any>;
-  queryString?: Dictionary<any>;
+  headers?: any; // {[name: string]: string};
+  queryString?: any; // {[key: string]: string};
 }
 
 export interface GetOptions extends BaseOptions {
@@ -22,7 +21,7 @@ export type PutOptions = PostOptions;
 export interface Response {
   statusCode: number;
   body: string;
-  headers: Dictionary<any>;
+  headers: any; // {[name: string]: string};
 }
 
 export interface HttpIo {

--- a/src/lib/interfaces/native-api/conversation.ts
+++ b/src/lib/interfaces/native-api/conversation.ts
@@ -1,4 +1,3 @@
-import { EmptyObject } from "../utils";
 import { MessageResource } from "./resources";
 
 export interface ThreadProperties {
@@ -20,7 +19,8 @@ export interface Conversation {
     // example: "1461605505609;1461605570732;10435004700722293356"
     consumptionhorizon?: string;
   };
-  lastMessage: EmptyObject | MessageResource;
+  // TODO: Check if empty object really occurs
+  lastMessage: {} | MessageResource;
   // https://{host}/v1/users/ME/contacts/{thread}/messages (even if targetLink points to /v1/threads)
   messages: string;
 }

--- a/src/lib/interfaces/utils.ts
+++ b/src/lib/interfaces/utils.ts
@@ -1,7 +1,0 @@
-export interface Dictionary<T> {
-  [key: string]: T;
-}
-
-export type Nullable <T> = T;
-
-export interface EmptyObject {}

--- a/src/lib/mri.ts
+++ b/src/lib/mri.ts
@@ -1,0 +1,264 @@
+// tslint:disable:max-line-length
+/**
+ * This module handles MRI keys
+ *
+ * MRI may stand for MSN Resource Identifier (open an issue if you have a better idea).
+ *
+ * An MRI key is a string of the format: `${type}:${id}` where `id` can be a string of (at least)
+ * ascii letters and digits (it cannot start by `\d+:`) and `type` is a decimal code.
+ *
+ * Examples:
+ * - `1:bob`
+ * - `4:+15553485`
+ * - `8:bob`
+ * - `8:guest:bob`
+ * - `8:live:bob`
+ *
+ * @see https://github.com/demurgos/skype-web-reversed/tree/bb30da685fb7d2d06f1ba740283d6cbbaeb2c502/skype/latest/decompiled/fullExperience/rjs%24%24swx-mri/lib
+ */
+// tslint:enable
+
+import { Incident } from "incident";
+
+/**
+ * Represents a well-formed MRI key.
+ */
+export type MriKey = string;
+
+/**
+ * Represents a parsed MRI key
+ */
+export interface ParsedMriKey {
+  /**
+   * MRI type.
+   */
+  type: MriType;
+
+  /**
+   * MRI id, cannot begin by `\d+:`.
+   */
+  id: string;
+}
+
+export enum MriType {
+  Agent = "agent",
+  Lync = "lync",
+  Msn = "msn",
+  Skype = "skype",
+  /**
+   * Public switched telephone network
+   */
+  Pstn = "pstn",
+}
+
+/**
+ * Represents a valid MRI type code.
+ *
+ * @internal
+ */
+export type MriTypeCode = "1" | "2" | "4" | "8" | "28";
+
+const MRI_TYPE_TO_TYPE_CODE: Map<MriType, MriTypeCode> = new Map<MriType, MriTypeCode>([
+  [MriType.Agent, "28"],
+  [MriType.Lync, "2"],
+  [MriType.Msn, "1"],
+  [MriType.Skype, "8"],
+  [MriType.Pstn, "4"],
+]);
+
+const MRI_TYPE_FROM_TYPE_CODE: Map<MriTypeCode, MriType> = reverseMap(MRI_TYPE_TO_TYPE_CODE);
+
+/**
+ * Represents a valid MRI type name.
+ *
+ * @internal
+ */
+export type MriTypeName = "agent" | "lync" | "msn" | "skype" | "pstn";
+
+const MRI_TYPE_TO_TYPE_NAME: Map<MriType, MriTypeName> = new Map<MriType, MriTypeName>([
+  [MriType.Agent, "agent"],
+  [MriType.Lync, "lync"],
+  [MriType.Msn, "msn"],
+  [MriType.Skype, "skype"],
+  [MriType.Pstn, "pstn"],
+]);
+
+const MRI_TYPE_FROM_TYPE_NAME: Map<MriTypeName, MriType> = reverseMap(MRI_TYPE_TO_TYPE_NAME);
+
+// TODO: Move outside of this module
+function reverseMap<K, V>(source: Map<K, V>): Map<V, K> {
+  const result: Map<V, K> = new Map();
+  for (const [key, value] of source.entries()) {
+    if (result.has(value)) {
+      throw new Incident("DuplicateValue", {map: source});
+    }
+    result.set(value, key);
+  }
+  return result;
+}
+
+/**
+ * Converts an MRI type to the corresponding MRI type code.
+ *
+ * @param type The MRI type.
+ * @return The corresponding MRI type code.
+ * @internal
+ */
+export function mriTypeToTypeCode(type: MriType): MriTypeCode {
+  const result: MriTypeCode | undefined = MRI_TYPE_TO_TYPE_CODE.get(type);
+  if (result === undefined) {
+    throw new Incident("UnknownMriType", {type});
+  }
+  return result;
+}
+
+/**
+ * Converts an MRI type code to the corresponding MRI type.
+ *
+ * @param typeCode The MRI type code.
+ * @return The corresponding MRI type.
+ * @internal
+ */
+export function mriTypeFromTypeCode(typeCode: MriTypeCode): MriType {
+  const result: MriType | undefined = MRI_TYPE_FROM_TYPE_CODE.get(typeCode);
+  if (result === undefined) {
+    throw new Incident("UnknownMriTypeCode", {typeCode});
+  }
+  return result;
+}
+
+/**
+ * Converts an MRI type to the corresponding MRI type name.
+ *
+ * @param type The MRI type.
+ * @return The corresponding MRI type name.
+ * @internal
+ */
+export function mriTypeToTypeName(type: MriType): MriTypeName {
+  const result: MriTypeName | undefined = MRI_TYPE_TO_TYPE_NAME.get(type);
+  if (result === undefined) {
+    throw new Incident("UnknownMriType", {type});
+  }
+  return result;
+}
+
+/**
+ * Converts an MRI type name to the corresponding MRI type.
+ *
+ * @param typeName The MRI type name.
+ * @return The corresponding MRI type.
+ * @internal
+ */
+export function mriTypeFromTypeName(typeName: MriTypeName): MriType {
+  const result: MriType | undefined = MRI_TYPE_FROM_TYPE_NAME.get(typeName);
+  if (result === undefined) {
+    throw new Incident("UnknownMriTypeName", {typeName});
+  }
+  return result;
+}
+
+/**
+ * Pattern matching MRI keys. It has two capture groups:
+ * - Group 1: Type code
+ * - Group 2: Id
+ *
+ * The universal matcher for the id part matches the behavior found in
+ * skype-web-reversed (v1.107.13).
+ * There is still a difference: we assume that there is a single type code prefix while
+ * the retrieved regexp is `/^(?:(\d+):)+/`.
+ * This means that they can parse `4:8:bob` to the type code `"8"` and id `"bob"`.
+ * Instead of that, our pattern parses to the type code `"4"` and id `"8:bob"` (but then
+ * the parse function throws an error because the `id` is invalid).
+ */
+const MRI_KEY_PATTERN: RegExp = /^(\d+):([\s\S]+)$/;
+
+export function getId(mriKey: MriKey): string {
+  return parse(mriKey).id;
+}
+
+export function getType(mriKey: MriKey): MriType {
+  return parse(mriKey).type;
+}
+
+/**
+ * Tests if an id is Phone Switched Telephone Network (PSTN) identifier (a phone number).
+ *
+ * A PSTN id is a decimal number, optionally prefixed by a plus sign (`+`).
+ *
+ * @param id ID to test
+ * @return Boolean indicating if `id` is a PSTN id
+ */
+export function isPstnId(id: string): boolean {
+  return /^(?:\+)?\d+$/.test(id);
+}
+
+/**
+ * Tests if an id is guest identifier.
+ *
+ * A guest id starts by `guest:`.
+ *
+ * @param id ID to test
+ * @return Boolean indicating if `id` is a guest id
+ */
+export function isGuestId(id: string): boolean {
+  return /^guest:/.test(id);
+}
+
+/**
+ * Tests if a string is a well-formed MRI key.
+ *
+ * @param str The string to test
+ * @return Boolean indicating if `str` is a well-formed MRI key
+ */
+export function isMriKey(str: string): str is MriKey {
+  return /^(?:(\d+):)+/.test(str);
+}
+
+/**
+ * Creates an MRI key if needed
+ *
+ * If `mriKeyOrId` is already an MRI key, returns it immediately.
+ * Otherwise, creates an MRI key with the type `type` and id `mriKeyOrId`.
+ *
+ * @param {MriKey | string} mriKeyOrId
+ * @param {MriType} type
+ * @return {string}
+ */
+export function asMriKey(mriKeyOrId: MriKey | string, type: MriType): MriKey {
+  if (isMriKey(mriKeyOrId)) {
+    return mriKeyOrId;
+  }
+  const id: string = mriKeyOrId;
+  if (isPstnId(id)) {
+    // TODO: We are enforcing the PSTN type. We should check the value of `type` and raise a
+    //       warning if it is not Pstn.
+    return format({type: MriType.Pstn, id});
+  } else {
+    return format({type, id});
+  }
+}
+
+function isValidId(id: string): boolean {
+  return !MRI_KEY_PATTERN.test(id);
+}
+
+export function format(mri: ParsedMriKey): MriKey {
+  if (!isValidId(mri.id)) {
+    throw new Incident("InvalidMriId", {id: mri.id});
+  }
+  return `${mriTypeToTypeCode(mri.type)}:${mri.id}`;
+}
+
+export function parse(mri: MriKey): ParsedMriKey {
+  const match: RegExpExecArray | null = MRI_KEY_PATTERN.exec(mri);
+  if (match === null) {
+    throw new Incident("InvalidMriKey", {key: mri});
+  }
+  // We can cast here because `mriTypeFromTypeCode` tests the validity of the MRI code.
+  const type: MriType = mriTypeFromTypeCode(match[1] as MriTypeCode);
+  const id: string = match[2];
+  if (isValidId(id)) {
+    throw new Incident("InvalidMriId", {id});
+  }
+  return {type, id};
+}

--- a/src/lib/providers/microsoft-account.ts
+++ b/src/lib/providers/microsoft-account.ts
@@ -11,7 +11,6 @@ import { WrongCredentialsError } from "../errors/wrong-credentials";
 import { WrongCredentialsLimitError } from "../errors/wrong-credentials-limit";
 import { SkypeToken } from "../interfaces/api/context";
 import * as io from "../interfaces/http-io";
-import { Dictionary } from "../interfaces/utils";
 
 export const skypeWebUri: string = "https://web.skype.com/";
 export const skypeLoginUri: string = "https://login.skype.com/login/";
@@ -115,7 +114,7 @@ export interface LiveKeys {
 export async function getLiveKeys(options: LoadLiveKeysOptions): Promise<LiveKeys> {
   try {
     const uri: string = url.resolve(skypeLoginUri, path.posix.join("oauth", "microsoft"));
-    const queryString: Dictionary<string> = {
+    const queryString: {[key: string]: string} = {
       client_id: webClientLiveLoginId,
       redirect_uri: skypeWebUri,
     };
@@ -227,7 +226,7 @@ export async function getLiveToken(options: GetLiveTokenOptions): Promise<string
 // Get live token from live keys and credentials
 export async function requestLiveToken(options: GetLiveTokenOptions): Promise<io.Response> {
   const uri: string = url.resolve(liveLoginUri, path.posix.join("ppsecure", "post.srf"));
-  const queryString: Dictionary<string> = {
+  const queryString: {[key: string]: string} = {
     wa: "wsignin1.0",
     wp: "MBI_SSL",
     // tslint:disable-next-line:max-line-length
@@ -324,12 +323,12 @@ export async function getSkypeToken(options: GetSkypeTokenOptions): Promise<Skyp
 export async function requestSkypeToken(options: GetSkypeTokenOptions): Promise<io.Response> {
   const uri: string = url.resolve(skypeLoginUri, "microsoft");
 
-  const queryString: Dictionary<string> = {
+  const queryString: {[key: string]: string} = {
     client_id: "578134",
     redirect_uri: "https://web.skype.com",
   };
 
-  const formData: Dictionary<string> = {
+  const formData: {[key: string]: string} = {
     t: options.liveToken,
     client_id: "578134",
     oauthPartner: "999",

--- a/src/lib/types/agent-info.ts
+++ b/src/lib/types/agent-info.ts
@@ -1,0 +1,34 @@
+import { CaseStyle } from "kryo/case-style";
+import { ArrayType } from "kryo/types/array";
+import { BooleanType } from "kryo/types/boolean";
+import { DocumentType } from "kryo/types/document";
+import { JsonType } from "kryo/types/json";
+import { Ucs2StringType } from "kryo/types/ucs2-string";
+
+/**
+ * Example (concierge bot):
+ * ```
+ * {
+ *   "capabilities": [],
+ *   "trusted": true,
+ *   "type": "Participant"
+ * }
+ * ```
+ */
+export interface AgentInfo {
+  capabilities: any[];
+  trusted: boolean;
+  /**
+   * `"Participant" | ...`
+   */
+  type: string;
+}
+
+export const $AgentInfo: DocumentType<AgentInfo> = new DocumentType<AgentInfo>({
+  properties: {
+    capabilities: {type: new ArrayType({itemType: new JsonType(), maxLength: Infinity})},
+    trusted: {type: new BooleanType()},
+    type: {type: new Ucs2StringType({maxLength: Infinity})},
+  },
+  rename: CaseStyle.SnakeCase,
+});

--- a/src/lib/types/agent.ts
+++ b/src/lib/types/agent.ts
@@ -1,0 +1,49 @@
+import { CaseStyle } from "kryo/case-style";
+import { ArrayType } from "kryo/types/array";
+import { DocumentType } from "kryo/types/document";
+import { JsonType } from "kryo/types/json";
+import { Ucs2StringType } from "kryo/types/ucs2-string";
+import { $AgentInfo, AgentInfo } from "./agent-info";
+
+/**
+ * Example (concierge bot):
+ * ```
+ * {
+ *   "capabilities": [],
+ *   "trust": "not-trusted",
+ *   "type": "participant",
+ *   "info": {
+ *     "capabilities": [],
+ *     "trusted": true,
+ *     "type": "Participant"
+ *   },
+ *   "stage_info": {}
+ * }
+ * ```
+ */
+export interface Agent {
+  capabilities: any[];
+  /**
+   * `"participant" | ...`
+   */
+  type: string;
+  /**
+   * `"not-trusted" | ...`
+   */
+  trust: string;
+
+  info: AgentInfo;
+
+  stageInfo: any;
+}
+
+export const $Agent: DocumentType<Agent> = new DocumentType<Agent>({
+  properties: {
+    capabilities: {type: new ArrayType({itemType: new JsonType(), maxLength: Infinity})},
+    type: {type: new Ucs2StringType({maxLength: Infinity})},
+    trust: {type: new Ucs2StringType({maxLength: Infinity})},
+    info: {type: $AgentInfo},
+    stageInfo: {type: new JsonType()},
+  },
+  rename: CaseStyle.SnakeCase,
+});

--- a/src/lib/types/authorization-state.ts
+++ b/src/lib/types/authorization-state.ts
@@ -1,0 +1,9 @@
+/**
+ * Authorization state of other contacts.
+ */
+export enum AuthorizationState {
+  /**
+   * The other contact sent an invite to the current user that the current user hasn't accepted yet.
+   */
+  PendingIncoming,
+}

--- a/src/lib/types/contact-group.ts
+++ b/src/lib/types/contact-group.ts
@@ -1,0 +1,29 @@
+import { CaseStyle } from "kryo/case-style";
+import { BooleanType } from "kryo/types/boolean";
+import { DocumentType } from "kryo/types/document";
+import { Ucs2StringType } from "kryo/types/ucs2-string";
+
+/**
+ * Example:
+ * ```
+ * {
+ *   "id": "000C3765-A8A0-464C-8083-C8383B86A772",
+ *   "name": "Favorites",
+ *   "is_favorite": true
+ * }
+ * ```
+ */
+export interface ContactGroup {
+  id: string;
+  name: string;
+  isFavorite: boolean;
+}
+
+export const $ContactGroup: DocumentType<ContactGroup> = new DocumentType<ContactGroup>({
+  properties: {
+    id: {type: new Ucs2StringType({maxLength: Infinity})},
+    name: {type: new Ucs2StringType({maxLength: Infinity})},
+    isFavorite: {type: new BooleanType()},
+  },
+  rename: CaseStyle.SnakeCase,
+});

--- a/src/lib/types/contact.ts
+++ b/src/lib/types/contact.ts
@@ -1,0 +1,52 @@
+import { CaseStyle } from "kryo/case-style";
+import { BooleanType } from "kryo/types/boolean";
+import { DateType } from "kryo/types/date";
+import { DocumentType } from "kryo/types/document";
+import { Ucs2StringType } from "kryo/types/ucs2-string";
+import { $Agent, Agent } from "./agent";
+import { $DisplayName, DisplayName } from "./display-name";
+import { $DisplayNameSource, DisplayNameSource } from "./display-name-source";
+import { $MriKey, MriKey } from "./mri-key";
+import { $Profile, Profile } from "./profile";
+import { $RelationshipHistory, RelationshipHistory } from "./relationship-history";
+
+export interface Contact {
+  /**
+   * This seems to always have the same value as `mri`, prefer to use `mri` to identify
+   * the user.
+   */
+  personId: MriKey;
+  /**
+   * MRI key of this contact, this serves as the unique id for this contact.
+   */
+  mri: MriKey;
+  displayName: DisplayName;
+  displayNameSource: DisplayNameSource;
+  profile: Profile;
+  agent?: Agent;
+  authorized: boolean;
+  /**
+   * Base64 string, seems to depend on the value of `authorized` (absent when `false`)
+   */
+  authCertificate?: string;
+  blocked: boolean;
+  creationTime: Date;
+  relationshipHistory?: RelationshipHistory;
+}
+
+export const $Contact: DocumentType<Contact> = new DocumentType<Contact>({
+  properties: {
+    personId: {type: $MriKey},
+    mri: {type: $MriKey},
+    displayName: {type: $DisplayName},
+    displayNameSource: {type: $DisplayNameSource},
+    profile: {type: $Profile},
+    agent: {type: $Agent, optional: true},
+    authorized: {type: new BooleanType()},
+    authCertificate: {type: new Ucs2StringType({maxLength: Infinity}), optional: true},
+    blocked: {type: new BooleanType()},
+    creationTime: {type: new DateType()},
+    relationshipHistory: {type: $RelationshipHistory, optional: true},
+  },
+  rename: CaseStyle.SnakeCase,
+});

--- a/src/lib/types/display-name-source.ts
+++ b/src/lib/types/display-name-source.ts
@@ -1,0 +1,16 @@
+import { CaseStyle } from "kryo/case-style";
+import { SimpleEnumType } from "kryo/types/simple-enum";
+
+export enum DisplayNameSource {
+  Identifier,
+  Profile,
+  /**
+   * The display name was edited by the current user.
+   */
+  UserEdits,
+}
+
+export const $DisplayNameSource: SimpleEnumType<DisplayNameSource> = new SimpleEnumType<DisplayNameSource>({
+  enum: DisplayNameSource,
+  rename: CaseStyle.SnakeCase,
+});

--- a/src/lib/types/display-name.ts
+++ b/src/lib/types/display-name.ts
@@ -1,0 +1,5 @@
+import { Ucs2StringType } from "kryo/types/ucs2-string";
+
+export type DisplayName = string;
+
+export const $DisplayName: Ucs2StringType = new Ucs2StringType({maxLength: Infinity});

--- a/src/lib/types/invite-message.ts
+++ b/src/lib/types/invite-message.ts
@@ -1,0 +1,25 @@
+import { DateType } from "kryo/types/date";
+import { DocumentType } from "kryo/types/document";
+import { Ucs2StringType } from "kryo/types/ucs2-string";
+
+/**
+ * Example (JSON HTTP response):
+ *
+ * ```
+ * {
+ *  "message": "Hi Bob, I'd like to add you as a contact.",
+ *  "time": "2018-01-09T14:42:17Z"
+ * }
+ * ```
+ */
+export interface InviteMessage {
+  message: string;
+  time: Date;
+}
+
+export const $InviteMessage: DocumentType<InviteMessage> = new DocumentType<InviteMessage>({
+  properties: {
+    message: {type: new Ucs2StringType({maxLength: Infinity})},
+    time: {type: new DateType()},
+  },
+});

--- a/src/lib/types/invite.ts
+++ b/src/lib/types/invite.ts
@@ -1,0 +1,44 @@
+import { CaseStyle } from "kryo/case-style";
+import { ArrayType } from "kryo/types/array";
+import { DocumentType } from "kryo/types/document";
+import { $DisplayName, DisplayName } from "./display-name";
+import { $InviteMessage, InviteMessage } from "./invite-message";
+import { $MriKey, MriKey } from "./mri-key";
+import { $Url, Url } from "./url";
+
+/**
+ * Represents a pending incoming contact invitation.
+ */
+export interface Invite {
+  /**
+   * MRI key of the contact
+   *
+   * @see [[MriKey]]
+   */
+  mri: MriKey;
+
+  // TODO(demurgos): Rename to `displayName` once Kryo supports custom renames
+  displayname: DisplayName;
+
+  avatarUrl: Url;
+
+  /**
+   * All the messages received from this contact.
+   *
+   * Note: Skype only displays the most recent one (2017-01-09).
+   */
+  invites: InviteMessage[];
+}
+
+/**
+ * Runtime representation of the [[Invite]] type.
+ */
+export const $Invite: DocumentType<Invite> = new DocumentType<Invite>({
+  properties: {
+    mri: {type: $MriKey},
+    displayname: {type: $DisplayName},
+    avatarUrl: {type: $Url},
+    invites: {type: new ArrayType({itemType: $InviteMessage, maxLength: Infinity})},
+  },
+  rename: CaseStyle.SnakeCase,
+});

--- a/src/lib/types/iso-date.ts
+++ b/src/lib/types/iso-date.ts
@@ -1,0 +1,8 @@
+import { Ucs2StringType } from "kryo/types/ucs2-string";
+
+/**
+ * Represents a valid ISO 8601 date string: `YYYY-MM-DD`.
+ */
+export type IsoDate = string;
+
+export const $IsoDate: Ucs2StringType = new Ucs2StringType({maxLength: Infinity});

--- a/src/lib/types/location.ts
+++ b/src/lib/types/location.ts
@@ -1,0 +1,26 @@
+import { CaseStyle } from "kryo/case-style";
+import { DocumentType } from "kryo/types/document";
+import { Ucs2StringType } from "kryo/types/ucs2-string";
+
+export interface Location {
+  /**
+   * `"home" | "work" | ...`
+   */
+  type: string;
+  /**
+   * `"BE" | "FR" | "fr" ...`
+   */
+  country?: string;
+  city?: string;
+  state?: string;
+}
+
+export const $Location: DocumentType<Location> = new DocumentType<Location>({
+  properties: {
+    type: {type: new Ucs2StringType({maxLength: Infinity})},
+    country: {type: new Ucs2StringType({maxLength: Infinity}), optional: true},
+    city: {type: new Ucs2StringType({maxLength: Infinity}), optional: true},
+    state: {type: new Ucs2StringType({maxLength: Infinity}), optional: true},
+  },
+  rename: CaseStyle.SnakeCase,
+});

--- a/src/lib/types/mri-key.ts
+++ b/src/lib/types/mri-key.ts
@@ -1,0 +1,5 @@
+import { Ucs2StringType } from "kryo/types/ucs2-string";
+
+export { MriKey } from "../mri";
+
+export const $MriKey: Ucs2StringType = new Ucs2StringType({maxLength: Infinity});

--- a/src/lib/types/name.ts
+++ b/src/lib/types/name.ts
@@ -1,0 +1,30 @@
+import { CaseStyle } from "kryo/case-style";
+import { DocumentType } from "kryo/types/document";
+import { Ucs2StringType } from "kryo/types/ucs2-string";
+
+/**
+ * I don't think that all of the properties can be undefined at the same time. `first` is almost
+ * always there. The one time I saw it missing, `nickname` was there.
+ *
+ * Examples:
+ * - `{"first": "Skype", "company": "Skype"}`
+ * - `{"first": "Bob", "nickname": "bob"}`
+ * - `{"first": "John", "surname": "Doe", "nickname": "live:john"}`
+ * - `{"nickname": "motiontwin"}`
+ */
+export interface Name {
+  first?: string;
+  surname?: string;
+  nickname?: string;
+  company?: string;
+}
+
+export const $Name: DocumentType<Name> = new DocumentType<Name>({
+  properties: {
+    first: {type: new Ucs2StringType({maxLength: Infinity}), optional: true},
+    surname: {type: new Ucs2StringType({maxLength: Infinity}), optional: true},
+    nickname: {type: new Ucs2StringType({maxLength: Infinity}), optional: true},
+    company: {type: new Ucs2StringType({maxLength: Infinity}), optional: true},
+  },
+  rename: CaseStyle.SnakeCase,
+});

--- a/src/lib/types/online-status.ts
+++ b/src/lib/types/online-status.ts
@@ -1,0 +1,3 @@
+export enum OnlineStatus {
+  Unknown,
+}

--- a/src/lib/types/phone.ts
+++ b/src/lib/types/phone.ts
@@ -1,0 +1,22 @@
+import { CaseStyle } from "kryo/case-style";
+import { DocumentType } from "kryo/types/document";
+import { Ucs2StringType } from "kryo/types/ucs2-string";
+
+export interface Phone {
+  /**
+   * `"mobile"`
+   */
+  type?: string;
+  /**
+   * Example: `+15553485`
+   */
+  number: string;
+}
+
+export const $Phone: DocumentType<Phone> = new DocumentType<Phone>({
+  properties: {
+    type: {type: new Ucs2StringType({maxLength: Infinity})},
+    number: {type: new Ucs2StringType({maxLength: Infinity})},
+  },
+  rename: CaseStyle.SnakeCase,
+});

--- a/src/lib/types/profile.ts
+++ b/src/lib/types/profile.ts
@@ -1,0 +1,62 @@
+import { CaseStyle } from "kryo/case-style";
+import { ArrayType } from "kryo/types/array";
+import { DocumentType } from "kryo/types/document";
+import { Ucs2StringType } from "kryo/types/ucs2-string";
+import { $IsoDate, IsoDate } from "./iso-date";
+import { $Location, Location } from "./location";
+import { $Name, Name } from "./name";
+import { $Phone, Phone } from "./phone";
+import { $Url, Url } from "./url";
+
+export interface Profile {
+  /**
+   * Examples:
+   * - `https://avatar.skype.com/v1/avatars/:userId?auth_key=1601633273` (the authKey can be negative)
+   * - `https://avatar.skype.com/v1/avatars/:userId/public`
+   * - `https://az705183.vo.msecnd.net/dam/skype/media/concierge-assets/avatar/avatarcnsrg-144.png`
+   */
+  avatarUrl: Url;
+  birthday?: IsoDate;
+  /**
+   * `"male" | "female"`
+   */
+  gender?: string;
+  locations?: Location[];
+  phones: Phone[];
+  /**
+   * Can contain tags.
+   * Examples:
+   * - `"<ss type=\"music\">(music)</ss> Rick Astley - Never Gonna Give You Up"`
+   * - `"Foo &amp; bar"`
+   */
+  mood?: string;
+  name: Name;
+  about?: string;
+
+  /**
+   * Probably always an URL
+   * Example: `"https://go.skype.com/faq.skype.bot"`
+   */
+  website?: string;
+
+  /**
+   * `"en" | "fr"`
+   */
+  language?: string;
+}
+
+export const $Profile: DocumentType<Profile> = new DocumentType<Profile>({
+  properties: {
+    avatarUrl: {type: $Url},
+    birthday: {type: $IsoDate, optional: true},
+    gender: {type: new Ucs2StringType({maxLength: Infinity}), optional: true},
+    locations: {type: new ArrayType({itemType: $Location, maxLength: Infinity}), optional: true},
+    phones: {type: new ArrayType({itemType: $Phone, maxLength: Infinity}), optional: true},
+    mood: {type: new Ucs2StringType({maxLength: Infinity}), optional: true},
+    name: {type: $Name},
+    about: {type: new Ucs2StringType({maxLength: Infinity}), optional: true},
+    website: {type: new Ucs2StringType({maxLength: Infinity}), optional: true},
+    language: {type: new Ucs2StringType({maxLength: Infinity}), optional: true},
+  },
+  rename: CaseStyle.SnakeCase,
+});

--- a/src/lib/types/relationship-history.ts
+++ b/src/lib/types/relationship-history.ts
@@ -1,0 +1,27 @@
+import { CaseStyle } from "kryo/case-style";
+import { ArrayType } from "kryo/types/array";
+import { DocumentType } from "kryo/types/document";
+import { JsonType } from "kryo/types/json";
+
+export interface RelationshipHistory {
+  /**
+   * Example:
+   * ```
+   * [
+   *   {
+   *     "type": "add_contact",
+   *     "subtype": "t1",
+   *     "time": "2017-08-15T14:28:44Z"
+   *   }
+   * ]
+   * ```
+   */
+  sources: any[];
+}
+
+export const $RelationshipHistory: DocumentType<RelationshipHistory> = new DocumentType<RelationshipHistory>({
+  properties: {
+    sources: {type: new ArrayType({itemType: new JsonType(), maxLength: Infinity})},
+  },
+  rename: CaseStyle.SnakeCase,
+});

--- a/src/lib/types/url.ts
+++ b/src/lib/types/url.ts
@@ -1,0 +1,5 @@
+import { Ucs2StringType } from "kryo/types/ucs2-string";
+
+export type Url = string;
+
+export const $Url: Ucs2StringType = new Ucs2StringType({maxLength: Infinity});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,4 @@
 import _ from "lodash";
-import { Dictionary } from "./interfaces/utils";
 
 /**
  * Returns the number of seconds since epoch.
@@ -62,7 +61,7 @@ export function getTimezone(): string {
 const HTTP_HEADER_SEPARATOR: string = ";";
 const HTTP_HEADER_OPERATOR: string = "=";
 
-export function stringifyHeaderParams(params: Dictionary<string>) {
+export function stringifyHeaderParams(params: {[key: string]: string}) {
   const headerPairs: string[] = _.map(params, (value: string, key: string) => {
     if (value === undefined) {
       throw new Error(`Undefined value for the header: ${key}`);

--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -4,10 +4,10 @@ import { Contact } from "../interfaces/api/contact";
 import { Conversation, ThreadProperties } from "../interfaces/api/conversation";
 import { Contact as NativeContact, SearchContact as NativeSearchContact } from "../interfaces/native-api/contact";
 import {
-  Conversation as NativeConversation,
-  Thread as NativeThread,
+  Conversation as NativeConversation, Thread as NativeThread,
   ThreadMember as NativeThreadMember,
 } from "../interfaces/native-api/conversation";
+import { MriType, MriTypeCode, mriTypeFromTypeName, MriTypeName, mriTypeToTypeCode, mriTypeToTypeName } from "../mri";
 import { sanitizeXml } from "./user-data-processor";
 
 export function formatConversation(native: NativeConversation): Conversation {
@@ -84,14 +84,14 @@ function searchContactToPerson(native: NativeSearchContact): Contact {
 
   const phoneNumbers: any[] = [];
   const locations: any[] = [];
-  const type: string = "skype";
-  const typeKey: string = contactTypeNameToContactTypeKey(type);
+  const type: MriType = MriType.Skype;
+  const typeKey: MriTypeCode = mriTypeToTypeCode(type);
   let result: Contact;
   result = {
     id: {
       id: native.username,
       typeKey,
-      typeName: type,
+      typeName: mriTypeToTypeName(type),
       raw: `${typeKey}:${native.username}`,
     },
     emails: native.emails,
@@ -157,7 +157,9 @@ function contactToPerson(native: NativeContact): Contact {
     authorizationState = authorizationStates.PENDING_OUTGOING;
   }
 
-  const typeKey: string = contactTypeNameToContactTypeKey(native.type);
+  // We can safely cast here because `mriTypeFromTypeName` tests the validity of the name.
+  const type: MriType = mriTypeFromTypeName(native.type as MriTypeName);
+  const typeKey: MriTypeCode = mriTypeToTypeCode(type);
   const isAgent: boolean = native.type === "agent";
 
   let avatarUrl: string | null;
@@ -202,50 +204,6 @@ function contactToPerson(native: NativeContact): Contact {
     locations,
   };
   return result;
-}
-
-// github:demurgos/skype-web-reversed -> jSkype/modelHelpers/contacts/dataMappers/dataMaps.js
-function contactTypeNameToContactTypeKey(typeName: string) {
-  switch (typeName) {
-    case "msn":
-      return "1";
-    case "lync":
-      return "2";
-    case "pstn":
-      return "4"; // Public switched telephone network
-    case "skype":
-      return "8";
-    case "agent":
-      return "28";
-    default:
-      throw new Incident(
-        "unknown-contact-type-name",
-        {typeName},
-        `Unknwon contact type name ${typeName}`,
-      );
-  }
-}
-
-// github:demurgos/skype-web-reversed -> jSkype/modelHelpers/contacts/dataMappers/dataMaps.js
-function contactTypeKeyToContactTypeName(typeKey: string) {
-  switch (typeKey) {
-    case "1":
-      return "msn";
-    case "2":
-      return "lync";
-    case "4":
-      return "pstn"; // Public switched telephone network
-    case "8":
-      return "skype";
-    case "28":
-      return "agent";
-    default:
-      throw new Incident(
-        "unknown-contact-type-key",
-        {typeCode: typeKey},
-        `Unknwon contact type key ${typeKey}`,
-      );
-  }
 }
 
 // github:demurgos/skype-web-reversed -> jSkype/modelHelpers/contacts/dataMappers/dataMaps.js


### PR DESCRIPTION
This commit uses the new contacts API to get all the contacts.
Retrieving a single contact is no longer possible.
Accepting and rejecting contact requests will need to be updated
as well (it still uses the old API).

New types were written for this update. The new types are in the
`types` directory must be imported using deep imports
(`import {Contact} from "skype-http/types/contact";`).
The old types are still in `lib/interfaces` for the moment.

**This is a breaking change.**

@James91
You should be able to install it with `skype-http@next` once it is merged. Could you check if it fixes your issue?
