### PR TITLE
Release v0.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.0.14 (2018-01-12)
 
 - **[Breaking change]** Use contacts API v2: the new types are in `lib/types`, the old types
     remain in `lib/interfaces`. The main difference is that the MRI key (`8:user_id`) is no longer

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2016 Charles Samborski, shyyko.serhiy
+Copyright (c) 2015-2018 Charles Samborski, shyyko.serhiy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "skype-http",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skype-http",
   "description": "Unofficial Skype API for Node.js via HTTP",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "license": "MIT",
   "main": "dist/lib/index",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
- **[Breaking change]** Use contacts API v2: the new types are in `lib/types`, the old types
    remain in `lib/interfaces`. The main difference is that the MRI key (`8:user_id`) is no longer
    parsed and most of the contact details are now in a `Profile` object.
    It is no longer possible to get a single contact.
- **[Feature]** Expose detailed errors for endpoint registration.
- **[Feature]** Support ES modules (ESM)
- **[Fix]** Add support email login (#58)
- **[Internal]** Update project tools to [turbo-gulp](https://www.npmjs.com/package/turbo-gulp)
- **[Internal]** Enable integration with Codecov
- **[Internal]** Enable integration with Greenkeeper
- **[Internal]** Use runtime representation of the types with Kryo