### PR TITLE
Mark `isFavorite` in `ContactGroup` as optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - **[Fix]** Do not throw on unexpected extra keys when reading responses.
 - **[Fix]** Fix message host resolution (API change).
+- **[Fix]** Mark `isFavorite` in `ContactGroup` as optional.
+- **[Fix]** Mark `name` in `ContactProfile` as optional.
 
 # 0.0.14 (2018-01-12)
 

--- a/src/lib/types/contact-group.ts
+++ b/src/lib/types/contact-group.ts
@@ -16,14 +16,14 @@ import { Ucs2StringType } from "kryo/types/ucs2-string";
 export interface ContactGroup {
   id: string;
   name: string;
-  isFavorite: boolean;
+  isFavorite?: boolean;
 }
 
 export const $ContactGroup: DocumentType<ContactGroup> = new DocumentType<ContactGroup>({
   properties: {
     id: {type: new Ucs2StringType({maxLength: Infinity})},
     name: {type: new Ucs2StringType({maxLength: Infinity})},
-    isFavorite: {type: new BooleanType()},
+    isFavorite: {type: new BooleanType(), optional: true},
   },
   rename: CaseStyle.SnakeCase,
   ignoreExtraKeys: true,


### PR DESCRIPTION
- Reported by @MrKoookaburra in ocilo/skype-http#73
- Closes ocilo/skype-http#78 (superseded)