### PR TITLE
Run tests and coverage on `.mjs` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **[Fix]** Fix message host resolution (API change).
 - **[Fix]** Mark `isFavorite` in `ContactGroup` as optional.
 - **[Fix]** Mark `name` in `ContactProfile` as optional.
+- **[Internal]** Run tests and coverage on `.mjs` files.
 
 # 0.0.14 (2018-01-12)
 

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -84,6 +84,7 @@ const test: buildTools.MochaTarget = {
   scripts: ["test/**/*.ts", "lib/**/*.ts"],
   customTypingsDir: "src/custom-typings",
   tsconfigJson: "src/test/tsconfig.json",
+  outModules: buildTools.OutModules.Mjs,
   tscOptions: {
     skipLibCheck: true,
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9072,6 +9072,14 @@
         "webpack": "3.10.0",
         "webpack-merge": "4.1.1",
         "webpack-stream": "4.0.0"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "2.7.0-dev.20180109",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.0-dev.20180109.tgz",
+          "integrity": "sha512-/0Zwo+4gpa9H2mXiWJzcu8BFd0hGvjGcp88z109I5pZ+z2shSy/94U5363hpwmxjv1/FtSd06qMDpAkIIqEEpw==",
+          "dev": true
+        }
       }
     },
     "tweetnacl": {
@@ -9170,9 +9178,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.7.0-dev.20180109",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.0-dev.20180109.tgz",
-      "integrity": "sha512-/0Zwo+4gpa9H2mXiWJzcu8BFd0hGvjGcp88z109I5pZ+z2shSy/94U5363hpwmxjv1/FtSd06qMDpAkIIqEEpw==",
+      "version": "2.7.0-rc",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.0-rc.tgz",
+      "integrity": "sha512-uQpL5isp2Pnn0N4mvow85Ob0Nwqr7fD6wME0pmBZ/RYad9OTIry4aTsfnsLa0lnOKvs2FRRm/TRHoc/fgn19wg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "cheerio": "^1.0.0-rc.2",
     "incident": "^3.1.0",
     "js-sha256": "^0.9.0",
-    "kryo": "^0.6.0-build.161",
+    "kryo": "^0.6.0",
     "lodash": "^4.17.4",
     "request": "^2.83.0",
     "tough-cookie": "^2.3.3"
@@ -63,6 +63,21 @@
     "ts-node": "^4.0.0",
     "tslint": "^5.8.0",
     "turbo-gulp": "^0.16.0",
-    "typescript": "2.7.0-dev.20180109"
+    "typescript": "^2.7.0-rc"
+  },
+  "nyc": {
+    "include": [
+      "build/test/lib/**/*.mjs"
+    ],
+    "reporter": [
+      "text",
+      "html"
+    ],
+    "extension": [
+      ".mjs"
+    ]
+  },
+  "@std/esm": {
+    "esm": "cjs"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3109,7 +3109,7 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
-kryo@^0.6.0-build.161:
+kryo@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/kryo/-/kryo-0.6.0.tgz#e0ca4f357e77dddd02e103d028a25a225582cd3c"
   dependencies:
@@ -5421,6 +5421,10 @@ typescript@2.4.1:
 typescript@2.7.0-dev.20180109:
   version "2.7.0-dev.20180109"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.0-dev.20180109.tgz#8ffb23a38903b7ba7abff12b7d5c10dc2675c987"
+
+typescript@^2.7.0-rc:
+  version "2.7.0-rc"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.0-rc.tgz#bf86a065a3a0be1e072c3fb7d64e8976f33b8365"
 
 uglify-js@^2.6, uglify-js@^2.6.1, uglify-js@^2.8.29:
   version "2.8.29"


### PR DESCRIPTION
This commit prioritizes the upcoming ESM modules by running the tests
and coverage on the ESM build with `.mjs` files.